### PR TITLE
Integrate bathroom fixture clearances into layout

### DIFF
--- a/tests/test_arrange_bathroom.py
+++ b/tests/test_arrange_bathroom.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from vastu_all_in_one import arrange_bathroom, BATH_RULES, CELL_M
+
+
+def _find_rect(plan, code):
+    rect = None
+    for y, row in enumerate(plan.occ):
+        for x, c in enumerate(row):
+            if c == code:
+                if rect is None:
+                    rect = [x, y, x, y]
+                else:
+                    rect[0] = min(rect[0], x)
+                    rect[1] = min(rect[1], y)
+                    rect[2] = max(rect[2], x)
+                    rect[3] = max(rect[3], y)
+    if rect is None:
+        return None
+    x1, y1, x2, y2 = rect
+    return x1, y1, x2 - x1 + 1, y2 - y1 + 1
+
+
+def test_arrange_bathroom_respects_clearances():
+    plan = arrange_bathroom(3.0, 3.5, BATH_RULES)
+
+    # fixtures should be present
+    for code in ("WC", "LAV", "TUB", "SHR"):
+        assert _find_rect(plan, code) is not None
+
+    # clearance rectangles must remain empty
+    for x, y, w, h, _, _ in plan.clearzones:
+        for j in range(y, y + h):
+            for i in range(x, x + w):
+                assert plan.occ[j][i] is None
+
+    wc = _find_rect(plan, "WC")
+    lav = _find_rect(plan, "LAV")
+    gap_cells = lav[0] - (wc[0] + wc[2])
+    required = BATH_RULES["fixtures"]["lavatory"]["to_adjacent_fixture_edge_m"]["min"]
+    assert gap_cells * CELL_M >= required
+


### PR DESCRIPTION
## Summary
- parse fixture clearance requirements from `rules.bathroom.json`
- enforce front and adjacency clearances when arranging bathroom fixtures
- add tests ensuring fixtures respect defined clearances

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ea644f708330bd7e573b95a9eca8