### PR TITLE
Allow tolerance for shared-wall door alignment

### DIFF
--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -30,8 +30,10 @@ def test_shared_wall_door_alignment_passes():
     gv = make_generate_view((2.0, 2.0))
     gv.bed_openings.door_wall = WALL_RIGHT
     gv.bath_openings.door_wall = WALL_LEFT
-    gv.bed_openings.door_center = gv.bath_openings.door_center = 1.0
-    gv.bed_openings.door_width = gv.bath_openings.door_width = 0.9
+    gv.bed_openings.door_center = 1.0
+    gv.bath_openings.door_center = 1.25  # 1 cell offset
+    gv.bed_openings.door_width = 0.9
+    gv.bath_openings.door_width = 1.15  # width differs by 1 cell
 
     assert gv._validate_shared_wall_door() is True
     assert gv.status.msg == ''
@@ -42,8 +44,8 @@ def test_shared_wall_door_alignment_passes():
     [
         (
             (2.0, 2.0),
-            1.25,
-            'Door must align on shared wall between bedroom and bathroom.',
+            1.5,
+            'Doors on shared wall must overlap (±1 cell tolerance).',
         ),
         (
             None,

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -2449,11 +2449,11 @@ class GenerateView:
                 if not (
                     b_wall == WALL_RIGHT
                     and bath_wall == WALL_LEFT
-                    and b_start == bath_start
-                    and b_width == bath_width
+                    and abs(b_start - bath_start) <= 1
+                    and abs(b_width - bath_width) <= 1
                 ):
                     self.status.set(
-                        'Door must align on shared wall between bedroom and bathroom.'
+                        'Doors on shared wall must overlap (±1 cell tolerance).'
                     )
                     return False
         else:


### PR DESCRIPTION
## Summary
- relax bedroom/bathroom door alignment check to allow ±1 cell differences in start and width
- adjust tests to verify tolerance and updated error messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4ec48b6d883309db73cd155ca91c6