### PR TITLE
Draw furniture beneath walls

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -2583,10 +2583,6 @@ class GenerateView:
             for j in range(gh + 1):
                 y = oy + j * scale
                 cv.create_line(ox, y, ox + gw * scale, y, fill='#2c2c2c')
-            cv.create_rectangle(ox, oy, ox + gw * scale, oy + gh * scale,
-                                outline=WALL_COLOR, width=thick)
-            self._draw_room_openings(cv, openings, ox, oy, scale, thick)
-
             bound = set()
             for j in range(gh):
                 for i in range(gw):
@@ -2612,6 +2608,9 @@ class GenerateView:
                 cv.create_rectangle(x0, y0, x0 + w * scale, y0 + h * scale,
                                     outline=PALETTE['CLEAR'], dash=(8, 6), width=2)
 
+            cv.create_rectangle(ox, oy, ox + gw * scale, oy + gh * scale,
+                                outline=WALL_COLOR, width=thick)
+            self._draw_room_openings(cv, openings, ox, oy, scale, thick)
         draw_room(self.bed_plan, self.bed_openings, bed_ox, bed_oy)
         if self.bath_plan:
             draw_room(self.bath_plan, self.bath_openings, bath_ox, bath_oy)


### PR DESCRIPTION
## Summary
- Render furniture fills and clearance zones before wall and opening elements
- Ensure walls, doors, and windows draw last so they appear above other items

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4fcfff568833096a43d4994fd45a2