### PR TITLE
Propagate bathroom opening controls to arranger

### DIFF
--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -67,7 +67,7 @@ def test_bedroom_door_on_shared_wall_sets_status(monkeypatch):
         def run(self):
             return self.plan, {'score': 1.0, 'coverage': 0.5, 'paths_ok': True, 'reach_windows': True}
 
-    def dummy_arrange_bathroom(w, h, rules, rng=None):
+    def dummy_arrange_bathroom(w, h, rules, openings=None, rng=None):
         return GridPlan(w, h)
 
     monkeypatch.setattr(vastu_all_in_one, 'BedroomSolver', DummyBedroomSolver)
@@ -97,7 +97,7 @@ def test_bathroom_door_not_on_shared_wall_skips_bath(monkeypatch):
         def run(self):
             return self.plan, {'score': 1.0, 'coverage': 0.5, 'paths_ok': True, 'reach_windows': True}
 
-    def dummy_arrange_bathroom(w, h, rules, rng=None):
+    def dummy_arrange_bathroom(w, h, rules, openings=None, rng=None):
         return GridPlan(w, h)
 
     monkeypatch.setattr(vastu_all_in_one, 'BedroomSolver', DummyBedroomSolver)
@@ -128,7 +128,7 @@ def test_valid_shared_wall_bathroom_door_generates_furniture(monkeypatch):
             self.plan.place(0, 0, 1, 1, 'BED')
             return self.plan, {'score': 1.0, 'coverage': 0.5, 'paths_ok': True, 'reach_windows': True}
 
-    def dummy_arrange_bathroom(w, h, rules, rng=None):
+    def dummy_arrange_bathroom(w, h, rules, openings=None, rng=None):
         plan = GridPlan(w, h)
         plan.place(0, 0, 1, 1, 'WC')
         return plan
@@ -188,7 +188,7 @@ def test_apply_batch_and_generate_uses_rng_and_updates_status(monkeypatch):
             return self.plan, {'score': 1.0, 'coverage': 0.0, 'paths_ok': True, 'reach_windows': True}
 
     seen = {}
-    def dummy_arrange_bathroom(w, h, rules, rng=None):
+    def dummy_arrange_bathroom(w, h, rules, openings=None, rng=None):
         seen['rng'] = rng
         return GridPlan(w, h)
 
@@ -211,7 +211,7 @@ def test_locked_bath_item_reapplied_after_generate(monkeypatch):
         def run(self):
             return self.plan, {'score': 1.0, 'coverage': 0.0, 'paths_ok': True, 'reach_windows': True}
 
-    def dummy_arrange_bathroom(w, h, rules, rng=None):
+    def dummy_arrange_bathroom(w, h, rules, openings=None, rng=None):
         return GridPlan(w, h)
 
     monkeypatch.setattr(vastu_all_in_one, 'BedroomSolver', DummyBedroomSolver)

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -2035,14 +2035,22 @@ def add_door_clearance(p: GridPlan, op: Openings, owner: str):
 # Bathroom arranger (very light – placeholder)
 # -----------------------
 
-def arrange_bathroom(Wm: float, Hm: float, rules: Dict, rng: Optional[random.Random] = None) -> GridPlan:
+def arrange_bathroom(
+    Wm: float,
+    Hm: float,
+    rules: Dict,
+    openings: Optional[Openings] = None,
+    rng: Optional[random.Random] = None,
+) -> GridPlan:
     """Generate a bathroom layout honouring clearance rules.
 
     The function is intentionally lightweight – its goal is simply to place the
     four common fixtures (tub, shower, water closet and lavatory) while
     respecting the minimum clearances encoded in ``rules``.  It is **not** an
     optimiser; if the room is too small to satisfy the hard minimums a partially
-    filled plan may be returned.
+    filled plan may be returned.  ``openings`` describes door and window
+    positions that the caller may wish to honour (currently unused but accepted
+    for API compatibility).
     """
 
     def _intersects_clear(p: GridPlan, x: int, y: int, w: int, h: int) -> bool:
@@ -2565,7 +2573,11 @@ class GenerateView:
         self.bed_plan = bed_plan
         if self.bath_dims and bath_ok:
             self.bath_plan = arrange_bathroom(
-                self.bath_dims[0], self.bath_dims[1], BATH_RULES, random.Random()
+                self.bath_dims[0],
+                self.bath_dims[1],
+                BATH_RULES,
+                self.bath_openings,
+                random.Random(),
             )
             add_door_clearance(self.bath_plan, self.bath_openings, 'DOOR')
             bath_sticky = getattr(self, '_sticky_bath_items', [])
@@ -3234,7 +3246,12 @@ class GenerateView:
         self.plan = best
         self.bed_plan = best
         if self.bath_dims:
-            self.bath_plan = arrange_bathroom(self.bath_dims[0], self.bath_dims[1], BATH_RULES)
+            self.bath_plan = arrange_bathroom(
+                self.bath_dims[0],
+                self.bath_dims[1],
+                BATH_RULES,
+                self.bath_openings,
+            )
         meta = {
             'coverage': getattr(best, 'coverage', lambda: 0.0)(),
             'paths_ok': True,


### PR DESCRIPTION
## Summary
- allow arrange_bathroom to accept optional `openings` data
- pass bathroom door/window values from UI to `arrange_bathroom`
- update tests for new arrange_bathroom signature

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a50ae996588330801478a1b7e947cd