### PR TITLE
Make bathroom arrangement deterministic

### DIFF
--- a/tests/test_arrange_bathroom.py
+++ b/tests/test_arrange_bathroom.py
@@ -44,3 +44,22 @@ def test_arrange_bathroom_respects_clearances():
     required = BATH_RULES["fixtures"]["lavatory"]["to_adjacent_fixture_edge_m"]["min"]
     assert gap_cells * CELL_M >= required
 
+
+def test_arrange_bathroom_deterministic_and_uses_rule_sizes():
+    plan1 = arrange_bathroom(3.0, 3.5, BATH_RULES)
+    plan2 = arrange_bathroom(3.0, 3.5, BATH_RULES)
+
+    assert plan1.occ == plan2.occ
+    assert plan1.clearzones == plan2.clearzones
+
+    tub = _find_rect(plan1, "TUB")
+    shr = _find_rect(plan1, "SHR")
+
+    fx = BATH_RULES["fixtures"]
+    in_m = BATH_RULES.get("units", {}).get("IN_M", 0.0254)
+    expected_tub = plan1.meters_to_cells(min(fx["bathtub"]["common_lengths_m"]))
+    expected_shr = plan1.meters_to_cells(min(s["w"] * in_m for s in fx["shower"]["stall_nominal_sizes_in"]))
+
+    assert tub[2] == expected_tub
+    assert shr[2] == expected_shr
+

--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -177,8 +177,7 @@ def test_apply_batch_and_generate_reruns_bed_and_bath(monkeypatch):
     assert components_by_code(gv.bath_plan, 'WC'), 'Bathroom furniture missing after regenerate'
 
 
-def test_apply_batch_and_generate_uses_rng_and_updates_status(monkeypatch):
-    import random
+def test_apply_batch_and_generate_updates_status(monkeypatch):
     import vastu_all_in_one
 
     class DummyBedroomSolver:
@@ -198,7 +197,7 @@ def test_apply_batch_and_generate_uses_rng_and_updates_status(monkeypatch):
     gv = make_generate_view((2.0, 2.0))
     gv._apply_batch_and_generate()
 
-    assert isinstance(seen.get('rng'), random.Random), 'arrange_bathroom missing RNG'
+    assert seen.get('rng') is None, 'arrange_bathroom should be deterministic'
     assert gv.status.msg == 'Bedroom and bathroom regenerated.'
 
 

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -2071,9 +2071,6 @@ def arrange_bathroom(Wm: float, Hm: float, rules: Dict, rng: Optional[random.Ran
             p.mark_clear(fx, fy, fw, fh, 'FRONT', code)
         return True
 
-    if rng is None:
-        rng = random.Random()
-
     p = GridPlan(Wm, Hm)
     units = rules.get('units', {})
     in_m = units.get('IN_M', 0.0254)
@@ -2089,10 +2086,11 @@ def arrange_bathroom(Wm: float, Hm: float, rules: Dict, rng: Optional[random.Ran
         'shr_front': fx.get('bathtub', {}).get('entry_front_clear_m', 0.762),
     }
 
-    tub_lengths = fx.get('bathtub', {}).get('common_lengths_m', [1.5])
-    shr_opts = fx.get('shower', {}).get('stall_nominal_sizes_in', [{'w': 36, 'd': 36}])
-    rng.shuffle(tub_lengths)
-    rng.shuffle(shr_opts)
+    tub_lengths = sorted(fx.get('bathtub', {}).get('common_lengths_m', [1.5]))
+    shr_opts = sorted(
+        fx.get('shower', {}).get('stall_nominal_sizes_in', [{'w': 36, 'd': 36}]),
+        key=lambda s: (s.get('w', 0) * s.get('d', 0), s.get('w', 0), s.get('d', 0))
+    )
 
     for tub_len in tub_lengths:
         for shr_size in shr_opts:
@@ -2565,7 +2563,7 @@ class GenerateView:
         self.bed_plan = bed_plan
         if self.bath_dims and bath_ok:
             self.bath_plan = arrange_bathroom(
-                self.bath_dims[0], self.bath_dims[1], BATH_RULES, random.Random()
+                self.bath_dims[0], self.bath_dims[1], BATH_RULES
             )
             add_door_clearance(self.bath_plan, self.bath_openings, 'DOOR')
             bath_sticky = getattr(self, '_sticky_bath_items', [])


### PR DESCRIPTION
## Summary
- Remove randomness from bathroom layout generation by iterating through fixture sizes in sorted order.
- Invoke `arrange_bathroom` in the generator without injecting a random seed.
- Add tests ensuring bathroom plans are deterministic and use rule-set dimensions; adjust generate view tests accordingly.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a50c5c715483308dac4288e3ffc109