### PR TITLE
Support shared-wall bathroom door clearance

### DIFF
--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -58,14 +58,20 @@ def make_generate_view(bath_dims=(2.0, 2.0)):
     return gv
 
 
-def test_bedroom_door_on_shared_wall_sets_status(monkeypatch):
+def test_bedroom_door_on_shared_wall_allows_generation(monkeypatch):
     import vastu_all_in_one
 
     class DummyBedroomSolver:
         def __init__(self, plan, *args, **kwargs):
             self.plan = plan
+
         def run(self):
-            return self.plan, {'score': 1.0, 'coverage': 0.5, 'paths_ok': True, 'reach_windows': True}
+            return self.plan, {
+                'score': 1.0,
+                'coverage': 0.5,
+                'paths_ok': True,
+                'reach_windows': True,
+            }
 
     def dummy_arrange_bathroom(w, h, rules, openings=None, rng=None):
         return GridPlan(w, h)
@@ -83,9 +89,9 @@ def test_bedroom_door_on_shared_wall_sets_status(monkeypatch):
 
     gv._solve_and_draw()
 
-    assert gv.status.msg == 'Bedroom door cannot be on shared wall.'
-    assert getattr(gv, 'bath_plan', None) is None
-    assert getattr(gv, 'bed_plan', None) is None
+    assert 'Bedroom door cannot be on shared wall.' not in gv.status.msg
+    assert isinstance(gv.bed_plan, GridPlan)
+    assert isinstance(gv.bath_plan, GridPlan)
 
 
 def test_bathroom_door_not_on_shared_wall_skips_bath(monkeypatch):


### PR DESCRIPTION
## Summary
- Initialise `GenerateView` with dedicated bathroom openings
- Parse bedroom and bathroom door/window controls separately
- Reserve door clearance on both bedroom and bathroom when sharing a wall
- Arrange bathrooms respecting door clearance from provided openings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a57d6e0e2c8330832bc8dfc01dae60