### PR TITLE
Implement door clearance in BedroomSolver

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -1898,6 +1898,19 @@ class BedroomSolver:
                     return (x,y,w,h)
         return None
 
+    def _add_door_clearance(self, p: GridPlan, owner: str):
+        wall, start, width = self.op.door_span_cells()
+        depth = p.meters_to_cells(self.op.swing_depth) + max(1, PATH_WIDTH_CELLS - 1)
+        pw = max(1, PATH_WIDTH_CELLS)
+        if wall == 0:
+            p.mark_clear(start, depth, width, pw, 'DOOR_CLEAR', owner)
+        elif wall == 2:
+            p.mark_clear(start, p.gh - depth - pw, width, pw, 'DOOR_CLEAR', owner)
+        elif wall == 3:
+            p.mark_clear(pw, start, pw, width, 'DOOR_CLEAR', owner)
+        else:
+            p.mark_clear(p.gw - depth - pw, start, pw, width, 'DOOR_CLEAR', owner)
+
     def _add_window_clearances(self, p:GridPlan):
         depth = max(1, p.meters_to_cells(0.40))
         for wall,start,length in self.op.window_spans_cells():


### PR DESCRIPTION
## Summary
- Add `_add_door_clearance` helper in `BedroomSolver` to mark the door swing zone on the grid plan.
- Ensure `_try_seed` uses this helper after writing the door block so door clearances are respected during bed placement.

## Testing
- `python -m py_compile vastu_all_in_one.py`


------
https://chatgpt.com/codex/tasks/task_e_68a59abc438883309ac3e6119249a4a6