### PR TITLE
Allow partial bathroom layouts when fixtures don't fit

### DIFF
--- a/tests/test_arrange_bathroom.py
+++ b/tests/test_arrange_bathroom.py
@@ -63,3 +63,14 @@ def test_arrange_bathroom_deterministic_and_uses_rule_sizes():
     assert tub[2] == expected_tub
     assert shr[2] == expected_shr
 
+
+def test_arrange_bathroom_partial_plan_when_space_limited():
+    """When some fixtures cannot fit the room, others should still be placed."""
+    plan = arrange_bathroom(1.2, 2.0, BATH_RULES)
+
+    # Tub is wider than the room; it should be omitted
+    assert _find_rect(plan, "TUB") is None
+
+    # Other fixtures that fit should still appear
+    assert _find_rect(plan, "WC") is not None or _find_rect(plan, "LAV") is not None or _find_rect(plan, "SHR") is not None
+


### PR DESCRIPTION
## Summary
- Skip bathroom fixtures that collide with door clearance or don't fit, returning the partial plan instead of aborting
- Guard every `p.place` with `p.fits` and place doors through the same check
- Add regression test for partial plans in tight rooms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a59e6557ec8330a92c62fe7cb3da9b