### PR TITLE
Handle bathroom door overlap in boundary placement

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -3134,11 +3134,25 @@ class GenerateView:
         dwall, dstart, dwidth = self.openings.door_span_cells()
         win_spans = self.openings.window_spans_cells()
 
+        # optional bathroom door span along shared left wall
+        bath_door_span = None
+        if getattr(self, 'bath_openings', None):
+            bwall, bstart, bwidth = self.bath_openings.door_span_cells()
+            if bwall == 3:  # left shared wall
+                bath_door_span = (bstart, bwidth)
+
         def spans_block(wall, x, y, w, h):
-            if wall == dwall and self._span_blocks_opening(wall, max(0, dstart-1), max(1, dwidth+2), x, y, w, h):
+            if wall == dwall and self._span_blocks_opening(
+                wall, max(0, dstart - 1), max(1, dwidth + 2), x, y, w, h
+            ):
                 return True
             for ww, start, L in win_spans:
                 if wall == ww and self._span_blocks_opening(wall, start, L, x, y, w, h):
+                    return True
+            if bath_door_span and wall == 3:
+                bx0, bx1 = bath_door_span[0], bath_door_span[0] + bath_door_span[1]
+                y0, y1 = y, y + h
+                if not (y1 <= bx0 or bx1 <= y0):
                     return True
             return False
 


### PR DESCRIPTION
## Summary
- prevent free-boundary furniture from blocking bathroom door on shared left wall

## Testing
- `python -m py_compile vastu_all_in_one.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5a6c71ccc83308500b1e56732a4e9