### PR TITLE
Handle bath door when placing boundary furniture

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -3152,11 +3152,22 @@ class GenerateView:
 
         # openings
         dwall, dstart, dwidth = self.openings.door_span_cells()
+        bath_door_span = None
+        if getattr(self, "bath_openings", None):
+            bwall, bstart, bwidth = self.bath_openings.door_span_cells()
+            if bwall == 3:  # shared left wall
+                bath_door_span = (bstart, bwidth)
         win_spans = self.openings.window_spans_cells()
 
         def spans_block(wall, x, y, w, h):
             if wall == dwall and self._span_blocks_opening(wall, max(0, dstart-1), max(1, dwidth+2), x, y, w, h):
                 return True
+            if bath_door_span and wall == 3:
+                if self._span_blocks_opening(3,
+                                             max(0, bath_door_span[0] - 1),
+                                             max(1, bath_door_span[1] + 2),
+                                             x, y, w, h):
+                    return True
             for ww, start, L in win_spans:
                 if wall == ww and self._span_blocks_opening(wall, start, L, x, y, w, h):
                     return True


### PR DESCRIPTION
## Summary
- Account for bathroom door span when placing boundary furniture to avoid blocking shared wall openings

## Testing
- `python -m py_compile vastu_all_in_one.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ae8857cc833080ec50dc0344e51a