### PR TITLE
Mark bathroom door clearance for bedroom plan

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -2636,6 +2636,14 @@ class GenerateView:
             self._draw()
             return
         bed_plan=GridPlan(self.bed_Wm,self.bed_Hm)
+        if self.bath_dims and self.bath_openings:
+            bwall, bstart, bwidth = self.bath_openings.door_span_cells()
+            if bwall == 3:  # left/shared wall
+                pw = max(1, PATH_WIDTH_CELLS)
+                bed_plan.mark_clear(
+                    pw, bstart, pw, bwidth,
+                    'DOOR_CLEAR', 'BATHROOM_DOOR'
+                )
         solver=BedroomSolver(
             bed_plan,
             self.bed_openings,


### PR DESCRIPTION
## Summary
- Reserve clear space on the bedroom plan for the bathroom door when it shares the left wall
- Ensure `BedroomSolver` accounts for bathroom openings while solving

## Testing
- `python -m py_compile vastu_all_in_one.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5c87f0d888330b37f0ea1a5382276