### PR TITLE
Align left-wall door clearance and reuse helper

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -2089,7 +2089,7 @@ def add_door_clearance(p: GridPlan, op: Openings, owner: str):
         p.mark_clear(start, p.gh - depth - max(1, PATH_WIDTH_CELLS), width,
                      max(1, PATH_WIDTH_CELLS), 'DOOR_CLEAR', owner)
     elif wall == 3:
-        p.mark_clear(max(1, PATH_WIDTH_CELLS), start, max(1, PATH_WIDTH_CELLS), width,
+        p.mark_clear(depth, start, max(1, PATH_WIDTH_CELLS), width,
                      'DOOR_CLEAR', owner)
     else:
         p.mark_clear(p.gw - depth - max(1, PATH_WIDTH_CELLS), start,
@@ -2643,13 +2643,9 @@ class GenerateView:
         bed_plan=GridPlan(self.bed_Wm,self.bed_Hm)
 
         if self.bath_dims and self.bath_openings:
-            bwall, bstart, bwidth = self.bath_openings.door_span_cells()
+            bwall, _, _ = self.bath_openings.door_span_cells()
             if bwall == WALL_LEFT:
-                depth = bed_plan.meters_to_cells(self.bath_openings.swing_depth) \
-                        + max(1, PATH_WIDTH_CELLS - 1)
-                bed_plan.mark_clear(0, bstart, depth, bwidth,
-                                    'DOOR_CLEAR', 'BATHROOM_DOOR')
-                print('DEBUG: marked bathroom door clearance', 0, bstart, depth, bwidth)
+                add_door_clearance(bed_plan, self.bath_openings, 'BATHROOM_DOOR')
 
         solver=BedroomSolver(
             bed_plan,


### PR DESCRIPTION
## Summary
- Offset left-wall door clearances by door swing depth to match right-wall behavior
- Simplify shared-wall bathroom door handling by calling `add_door_clearance` in solver

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5e2c38b348330a6a6873ee891f0af