### PR TITLE
Preserve negative door clearance coordinates

### DIFF
--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -525,3 +525,47 @@ def test_opening_control_limits(monkeypatch):
     assert comboboxes[3].kwargs['values'] == ['Left']
     assert 'Left' not in comboboxes[4].kwargs['values']
     assert 'Left' not in comboboxes[5].kwargs['values']
+
+
+def test_door_clearance_mirrors_across_shared_wall(monkeypatch):
+    import vastu_all_in_one
+
+    class DummyBedroomSolver:
+        def __init__(self, plan, *args, **kwargs):
+            self.plan = plan
+
+        def run(self):
+            return self.plan, {
+                'score': 1.0,
+                'coverage': 0.5,
+                'paths_ok': True,
+                'reach_windows': True,
+            }
+
+    def dummy_arrange_bathroom(w, h, rules, openings=None, rng=None):
+        return GridPlan(w, h)
+
+    monkeypatch.setattr(vastu_all_in_one, 'BedroomSolver', DummyBedroomSolver)
+    monkeypatch.setattr(vastu_all_in_one, 'arrange_bathroom', dummy_arrange_bathroom)
+
+    gv = make_generate_view((2.0, 2.0))
+    gv.bed_openings.door_wall = WALL_RIGHT
+    gv.bed_openings.door_center = 1.0
+    gv.bed_openings.door_width = 0.9
+    gv.bath_openings.door_wall = WALL_LEFT
+    gv.bath_openings.door_center = 1.0
+    gv.bath_openings.door_width = 0.9
+
+    gv._solve_and_draw()
+
+    bed_gw = gv.bed_plan.gw
+    combined = [
+        (x, y, w, h)
+        for x, y, w, h, kind, owner in gv.plan.clearzones
+        if kind == 'DOOR_CLEAR' and owner == 'BATHROOM_DOOR'
+    ]
+    bed_rect = [rect for rect in combined if rect[0] < bed_gw][0]
+    bath_rect = [rect for rect in combined if rect[0] >= bed_gw][0]
+
+    assert bed_rect[1:] == bath_rect[1:]
+    assert bed_gw - (bed_rect[0] + bed_rect[2]) == bath_rect[0] - bed_gw

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -1286,6 +1286,9 @@ class GridPlan:
         w=max(0,min(w, self.gw-x)); h=max(0,min(h, self.gh-y))
         if w>0 and h>0:
             self.clearzones.append((x,y,w,h,kind,owner))
+    def mark_clear_unclamped(self, x:int,y:int,w:int,h:int, kind:str, owner:str):
+        if w>0 and h>0:
+            self.clearzones.append((x,y,w,h,kind,owner))
     def meters_to_cells(self, m:float)->int:
         return max(1, int(ceil(m/self.cell)))
 
@@ -1986,7 +1989,7 @@ class BedroomSolver:
             outside = (2 * line - (inside[0] + pw), start, pw, width)
 
         p.mark_clear(*inside, 'DOOR_CLEAR', 'INSIDE')
-        p.mark_clear(*outside, 'DOOR_CLEAR', 'OUTSIDE')
+        p.mark_clear_unclamped(*outside, 'DOOR_CLEAR', 'OUTSIDE')
 
         return outside
 
@@ -2658,7 +2661,10 @@ class GenerateView:
         if openings is None:
             openings = self.bath_openings if p is self.bath_plan else self.bed_openings
         if openings:
-            return add_door_clearance(p, openings, owner)
+            ext = add_door_clearance(p, openings, owner)
+            if ext and ext[0] < 0 and getattr(self, 'bed_plan', None):
+                ext = (ext[0] + self.bed_plan.gw, ext[1], ext[2], ext[3])
+            return ext
         return None
 
     def _solve_and_draw(self):


### PR DESCRIPTION
## Summary
- Add `mark_clear_unclamped` to retain off-grid clearzone coordinates
- Use unclamped door-clear rectangles in bedroom solver and offset negatives in view generation
- Test that bedroom and bathroom door clearances mirror each other across shared wall

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a606d70cc483308ecdd51ee206a483