### PR TITLE
Use 2-cell door swing depth by default

### DIFF
--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -16,6 +16,7 @@ from vastu_all_in_one import (
     WALL_LEFT,
     WALL_TOP,
     WALL_BOTTOM,
+    CELL_M,
 )
 
 
@@ -38,7 +39,10 @@ def make_generate_view(bath_dims=(2.0, 2.0)):
     gv = GenerateView.__new__(GenerateView)
     gv.bath_dims = bath_dims
     gv.bed_openings = Openings(GridPlan(4.0, 4.0))
+    gv.bed_openings.swing_depth = 0.60
     gv.bath_openings = Openings(GridPlan(*bath_dims)) if bath_dims else None
+    if gv.bath_openings:
+        gv.bath_openings.swing_depth = 2 * CELL_M
     gv.status = DummyStatus()
     gv.sim_timer = None
     gv.sim2_timer = None

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -1308,7 +1308,8 @@ class Openings:
         self.door_wall=WALL_LEFT  # default orientation
         self.door_center=0.25*plan.Hm
         self.door_width=0.90
-        self.swing_depth=0.60
+        # Default door swing depth: 2 grid cells (0.5 m)
+        self.swing_depth = 2 * CELL_M
         # (wall, start_m, length_m)
         self.windows=[[1, plan.Hm*0.40, 1.20], [-1,0.0,0.0]]
     def door_rect_cells(self)->Tuple[int,int,int,int]:
@@ -2337,6 +2338,8 @@ class GenerateView:
         self._combine_plans()
 
         self.bed_openings = Openings(GridPlan(self.bed_Wm, self.bed_Hm))
+        # Bedroom doors retain the previous swing depth
+        self.bed_openings.swing_depth = 0.60
         self.openings = self.bed_openings  # maintain compatibility for bedroom ops
         self.bath_openings = (
             Openings(self.bath_plan) if bath_dims else None


### PR DESCRIPTION
## Summary
- Set `Openings` default door swing depth to `2 * CELL_M` (0.5 m)
- Restore bedroom door swing to 0.60 m after creating its `Openings`
- Adjust test fixture to explicitly use the updated swing depths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a86f1b6edc8330b97be28b3f6ed2ff