### PR TITLE
Add circular label markers to grid

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -3104,15 +3104,22 @@ class GenerateView:
 
         cg = getattr(self.plan, 'column_grid', None)
         if cg:
-            label_gap = 20
+            r = max(8, scale * 0.3)
+            label_gap = r * 2.5
             for i in range(cg.gw + 1):
                 x = ox + i * scale
-                cv.create_text(x, oy - label_gap, text=cg.col_label(i), fill='#555')
+                cx, cy = x, oy - label_gap
+                cv.create_oval(cx - r, cy - r, cx + r, cy + r,
+                               outline='#555', fill='white', width=1)
+                cv.create_text(cx, cy, text=cg.col_label(i), fill='#555')
                 for j in range(cg.gh + 1):
                     y = oy + j * scale
                     if i == 0:
-                        cv.create_text(ox - label_gap, y,
-                                       text=cg.row_label(cg.gh - j), fill='#555')
+                        cx, cy = ox - label_gap, y
+                        cv.create_oval(cx - r, cy - r, cx + r, cy + r,
+                                       outline='#555', fill='white', width=1)
+                        cv.create_text(cx, cy, text=cg.row_label(cg.gh - j),
+                                       fill='#555')
                     cv.create_oval(x - 2, y - 2, x + 2, y + 2,
                                    fill='#888', outline='', tags=('grid',))
 


### PR DESCRIPTION
## Summary
- Compute label positions with a radius-based gap and draw circular backgrounds
- Overlay column and row labels inside these circles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a878168b10833087c6f501d36187f6