### PR TITLE
Use single-cell swing depth for bathroom doors

### DIFF
--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -42,7 +42,7 @@ def make_generate_view(bath_dims=(2.0, 2.0)):
     gv.bed_openings.swing_depth = 0.60
     gv.bath_openings = Openings(GridPlan(*bath_dims)) if bath_dims else None
     if gv.bath_openings:
-        gv.bath_openings.swing_depth = 2 * CELL_M
+        gv.bath_openings.swing_depth = CELL_M
     gv.status = DummyStatus()
     gv.sim_timer = None
     gv.sim2_timer = None

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -1377,8 +1377,8 @@ class Openings:
         self.door_wall=WALL_LEFT  # default orientation
         self.door_center=0.25*plan.Hm
         self.door_width=0.90
-        # Default door swing depth: 2 grid cells (0.5 m)
-        self.swing_depth = 2 * CELL_M
+        # Default door swing depth: 1 grid cell
+        self.swing_depth = CELL_M
         # (wall, start_m, length_m)
         self.windows=[[1, plan.Hm*0.40, 1.20], [-1,0.0,0.0]]
     def door_rect_cells(self)->Tuple[int,int,int,int]:


### PR DESCRIPTION
## Summary
- Default Openings swing depth set to one grid cell
- Keep bedroom door swing depth at previous 0.60 m
- Update tests to expect one-cell bathroom door clearance

## Testing
- `pip install numpy -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a88d297f5c8330bfb4b42587e3a716