### PR TITLE
Guard placement with fits check and add regression test

### DIFF
--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -575,3 +575,10 @@ def test_mirrored_clearances_align_by_label(monkeypatch):
     bath_label = gv.bath_plan.coord_to_label(bath_clear[0], bath_clear[1])
 
     assert bed_label == bath_label
+
+
+def test_place_rejects_door_clear_overlap():
+    plan = GridPlan(2.0, 2.0)
+    plan.mark_clear(0, 0, 1, 1, 'DOOR_CLEAR', 'TEST')
+    with pytest.raises(ValueError):
+        plan.place(0, 0, 1, 1, 'BED')

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -1350,8 +1350,11 @@ class GridPlan:
                 return False
         return True
     def place(self, x:int,y:int,w:int,h:int, code:str):
+        if not self.fits(x, y, w, h):
+            raise ValueError("placement does not fit")
         for j in range(y,y+h):
-            for i in range(x,x+w): self.occ[j][i]=code
+            for i in range(x,x+w):
+                self.occ[j][i]=code
         return (x,y,w,h)
     def clear(self, x:int,y:int,w:int,h:int):
         for j in range(y,y+h):
@@ -3729,6 +3732,7 @@ class GenerateView:
         sticky = getattr(self, '_sticky_items', [])
         FRONT_REC_DEFAULT = {'WRD': 0.80, 'DRS': 0.90, 'DESK': 0.90, 'TVU': 0.75, 'BST': 0.75}
         for (code,x,y,w,h,wall) in sticky:
+            best.clear(x, y, w, h)
             best.place(x,y,w,h, code)
             # Re-apply clearances
             if code == 'BED':


### PR DESCRIPTION
## Summary
- Guard `GridPlan.place` with a `fits` call and raise an error when the requested placement is invalid
- Ensure sticky items are cleared before being re-placed during plan restoration
- Add regression test verifying placement fails when overlapping a `DOOR_CLEAR` zone

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a88f38019c8330b0a95b2eb84ad314