### PR TITLE
Ensure mark_clear empties region before recording

### DIFF
--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -629,6 +629,13 @@ def test_place_rejects_door_clear_overlap():
         plan.place(0, 0, 1, 1, 'BED')
 
 
+def test_mark_clear_removes_occupied_region():
+    plan = GridPlan(2.0, 2.0)
+    plan.place(0, 0, 1, 1, 'BED')
+    plan.mark_clear(0, 0, 1, 1, 'DOOR_CLEAR', 'TEST')
+    assert plan.occ[0][0] is None
+
+
 def test_grid_labels_fully_visible():
     plan = GridPlan(4.0, 4.0, column_grid=ColumnGrid(4, 4))
     gv = GenerateView.__new__(GenerateView)

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -1365,6 +1365,16 @@ class GridPlan:
         x=max(0,x); y=max(0,y)
         w=max(0,min(w, self.gw-x)); h=max(0,min(h, self.gh-y))
         if w>0 and h>0:
+            needs_clear = False
+            for j in range(y, y + h):
+                for i in range(x, x + w):
+                    if self.occ[j][i] is not None:
+                        needs_clear = True
+                        break
+                if needs_clear:
+                    break
+            if needs_clear:
+                self.clear(x, y, w, h)
             self.clearzones.append((x,y,w,h,kind,owner))
     def meters_to_cells(self, m:float)->int:
         return max(1, int(ceil(m/self.cell)))


### PR DESCRIPTION
## Summary
- Safeguard GridPlan.mark_clear by checking occupied cells before adding a clear zone and clearing them if necessary
- Add regression test verifying overlapping regions are cleared when marked

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a895ba8498833090c06789f53507bc