### PR TITLE
Reduce bed side clearance by two grid cells

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -1752,6 +1752,7 @@ class BedroomSolver:
             if not p.fits(jx,jy,w,h): return None,{},{}
             if not self._bed_touches_wall(jx,jy,w,h,seed['wall']): return None,{},{}
             side=p.meters_to_cells(self.c['side_rec']*(1.0-relax_factor) + self.c['side_min']*relax_factor)
+            side=max(0, side-2)
             foot=p.meters_to_cells(self.c['foot_rec']*(1.0-relax_factor) + self.c['foot_min']*relax_factor)
             if not self._clear_ok(p,jx,jy,w,h,seed['wall'],side,foot): return None,{},{}
             p.place(jx,jy,w,h,f'BED:{self.bed_key}')


### PR DESCRIPTION
## Summary
- Shrink left/right bed clearance by subtracting two cells to free space for bedside tables.
- Keep bedside table placements consistent with the new reduced clearance.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8992279048330b9e100eaa4c8a36f