### PR TITLE
Center dresser clearance

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -2041,20 +2041,24 @@ class BedroomSolver:
                     p.place(x,y,w,h, kind)
                     if 'front_rec' in spec:
                         fc = p.meters_to_cells(spec['front_rec'])
+                        clear_w, clear_x = w, x
+                        clear_h, clear_y = h, y
                         if kind == 'WRD' and wall in (0, 2) and w > 1:
                             clear_w = w - 1
                             clear_x = x + 0.5
-                        else:
-                            clear_w = w
-                            clear_x = x
+                        elif kind == 'DRS':
+                            clear_w = max(0, w - 2)
+                            clear_h = max(0, h - 2)
+                            clear_x = x + (w - clear_w) / 2
+                            clear_y = y + (h - clear_h) / 2
                         if wall == 0:
                             p.mark_clear(clear_x, y + h, clear_w, fc, 'FRONT', kind)
                         elif wall == 2:
                             p.mark_clear(clear_x, y - fc, clear_w, fc, 'FRONT', kind)
                         elif wall == 3:
-                            p.mark_clear(x + w, y, fc, h, 'FRONT', kind)
+                            p.mark_clear(x + w, clear_y, fc, clear_h, 'FRONT', kind)
                         else:
-                            p.mark_clear(x - fc, y, fc, h, 'FRONT', kind)
+                            p.mark_clear(x - fc, clear_y, fc, clear_h, 'FRONT', kind)
                     return (x,y,w,h)
         return None
 
@@ -2853,20 +2857,24 @@ class GenerateView:
                 fc_m = FRONT_REC_DEFAULT.get(code, 0.0)
                 if fc_m > 0.0:
                     fc = best.meters_to_cells(fc_m)
+                    clear_w, clear_x = w, x
+                    clear_h, clear_y = h, y
                     if code == 'WRD' and wall in (0, 2) and w > 1:
                         clear_w = w - 1
                         clear_x = x + 0.5
-                    else:
-                        clear_w = w
-                        clear_x = x
+                    elif code == 'DRS':
+                        clear_w = max(0, w - 2)
+                        clear_h = max(0, h - 2)
+                        clear_x = x + (w - clear_w) / 2
+                        clear_y = y + (h - clear_h) / 2
                     if wall == 0:
                         best.mark_clear(clear_x, y + h, clear_w, fc, 'FRONT', code)
                     elif wall == 2:
                         best.mark_clear(clear_x, y - fc, clear_w, fc, 'FRONT', code)
                     elif wall == 3:
-                        best.mark_clear(x + w, y, fc, h, 'FRONT', code)
+                        best.mark_clear(x + w, clear_y, fc, clear_h, 'FRONT', code)
                     elif wall == 1:
-                        best.mark_clear(x - fc, y, fc, h, 'FRONT', code)
+                        best.mark_clear(x - fc, clear_y, fc, clear_h, 'FRONT', code)
             best.clearzones = merge_clearances(best.clearzones)
 
         bed_plan = best
@@ -3370,12 +3378,21 @@ class GenerateView:
             W=p.meters_to_cells(spec['w']); D=p.meters_to_cells(spec['d'])
             placed=self._place_free_boundary('DRS', W, D, prefer_longedge=True)
             if placed:
-                x,y,w,h=placed; wall=self._infer_wall(x,y,w,h)
-                fc=p.meters_to_cells(spec['front_rec'])
-                if wall==0: p.mark_clear(x,y+h,w,fc,'FRONT','DRS')
-                elif wall==2: p.mark_clear(x,y-fc,w,fc,'FRONT','DRS')
-                elif wall==3: p.mark_clear(x+w,y,fc,h,'FRONT','DRS')
-                else: p.mark_clear(x-fc,y,fc,h,'FRONT','DRS')
+                x, y, w, h = placed
+                wall = self._infer_wall(x, y, w, h)
+                fc = p.meters_to_cells(spec['front_rec'])
+                clear_w = max(0, w - 2)
+                clear_h = max(0, h - 2)
+                clear_x = x + (w - clear_w) / 2
+                clear_y = y + (h - clear_h) / 2
+                if wall == 0:
+                    p.mark_clear(clear_x, y + h, clear_w, fc, 'FRONT', 'DRS')
+                elif wall == 2:
+                    p.mark_clear(clear_x, y - fc, clear_w, fc, 'FRONT', 'DRS')
+                elif wall == 3:
+                    p.mark_clear(x + w, clear_y, fc, clear_h, 'FRONT', 'DRS')
+                else:
+                    p.mark_clear(x - fc, clear_y, fc, clear_h, 'FRONT', 'DRS')
         elif kind in ('WRD_S_210','WRD_H_180'):
             spec=BEDROOM_BOOK['WARDROBE'][kind]
             W=p.meters_to_cells(spec['w']); D=p.meters_to_cells(spec['d'])
@@ -3809,20 +3826,24 @@ class GenerateView:
                 fc_m = FRONT_REC_DEFAULT.get(code, 0.0)
                 if fc_m > 0.0:
                     fc = best.meters_to_cells(fc_m)
+                    clear_w, clear_x = w, x
+                    clear_h, clear_y = h, y
                     if code == 'WRD' and wall in (0, 2) and w > 1:
                         clear_w = w - 1
                         clear_x = x + 0.5
-                    else:
-                        clear_w = w
-                        clear_x = x
+                    elif code == 'DRS':
+                        clear_w = max(0, w - 2)
+                        clear_h = max(0, h - 2)
+                        clear_x = x + (w - clear_w) / 2
+                        clear_y = y + (h - clear_h) / 2
                     if wall == 0:
                         best.mark_clear(clear_x, y + h, clear_w, fc, 'FRONT', code)
                     elif wall == 2:
                         best.mark_clear(clear_x, y - fc, clear_w, fc, 'FRONT', code)
                     elif wall == 3:
-                        best.mark_clear(x + w, y, fc, h, 'FRONT', code)
+                        best.mark_clear(x + w, clear_y, fc, clear_h, 'FRONT', code)
                     elif wall == 1:
-                        best.mark_clear(x - fc, y, fc, h, 'FRONT', code)
+                        best.mark_clear(x - fc, clear_y, fc, clear_h, 'FRONT', code)
 
         best.clearzones = merge_clearances(best.clearzones)
 


### PR DESCRIPTION
## Summary
- Center dresser front-clearance zones and reduce their width by 2 cells
- Apply the same width reduction and centering in automated dresser placement routines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89ba06e9c833083c216792c5b5ee4