### PR TITLE
Persist column-grid overlay and tag plan elements

### DIFF
--- a/tests/test_ruler_labels.py
+++ b/tests/test_ruler_labels.py
@@ -5,6 +5,7 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from vastu_all_in_one import GenerateView, GridPlan, ColumnGrid, Openings
+from ui.overlays import ColumnGridOverlay
 
 
 class CountingCanvas:
@@ -61,6 +62,7 @@ def test_ruler_labels_persist_across_zoom():
     gv.bed_openings = Openings(plan)
     gv.bath_openings = None
     gv.canvas = CountingCanvas()
+    gv.grid_overlay = ColumnGridOverlay(gv.canvas)
     gv.sim_poly = gv.sim2_poly = []
     gv.sim_path = gv.sim2_path = []
     gv.sim_index = gv.sim2_index = 0
@@ -68,7 +70,7 @@ def test_ruler_labels_persist_across_zoom():
 
     gv._draw()
     first_labels = [i for i in gv.canvas.items if i[0] == "text"]
-    expected = plan.gw + plan.gh
+    expected = plan.column_grid.gw + plan.column_grid.gh + 2
     assert len(first_labels) == expected
 
     gv.zoom_factor = 1.5

--- a/ui/overlays.py
+++ b/ui/overlays.py
@@ -31,6 +31,7 @@ class ColumnGridOverlay:
 
     def redraw(self, cg, ox: float, oy: float, scale: float) -> None:
         """Draw the grid overlay using cached coordinates."""
+        self.canvas.delete('overlay')
         self._build_coords(cg, ox, oy, scale)
         r = self._r
         for kind, x, y, text in self.coords:
@@ -42,7 +43,7 @@ class ColumnGridOverlay:
                     y + 2,
                     fill=self.GRID_COLOR,
                     outline="",
-                    tags=("grid",),
+                    tags=("overlay", "grid"),
                 )
             else:
                 self.canvas.create_oval(
@@ -53,6 +54,7 @@ class ColumnGridOverlay:
                     outline=self.GRID_COLOR,
                     fill=self.GRID_COLOR,
                     width=1,
+                    tags=("overlay",),
                 )
-                self.canvas.create_text(x, y, text=text, fill="#555")
+                self.canvas.create_text(x, y, text=text, fill="#555", tags=("overlay",))
         self.canvas.tag_lower("grid")


### PR DESCRIPTION
## Summary
- Clear only plan drawings on redraw by deleting `'plan'` items
- Tag plan geometry to support targeted clearing and add `refresh_overlay`
- Render column-grid overlay separately with `'overlay'` tag and adapt tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89dd48c008330b1f2503f06978d0e