### PR TITLE
Clamp wardrobe clearance to two cells

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -2068,6 +2068,8 @@ class BedroomSolver:
                     p.place(x,y,w,h, kind)
                     if 'front_rec' in spec:
                         fc = p.meters_to_cells(spec['front_rec'])
+                        if kind == 'WRD' and fc == 4:
+                            fc = 2
                         clear_w, clear_x = w, x
                         clear_h, clear_y = h, y
                         if kind == 'WRD' and wall in (0, 2) and w > 1:
@@ -2902,6 +2904,8 @@ class GenerateView:
                 fc_m = FRONT_REC_DEFAULT.get(code, 0.0)
                 if fc_m > 0.0:
                     fc = best.meters_to_cells(fc_m)
+                    if code == 'WRD' and fc == 4:
+                        fc = 2
                     clear_w, clear_x = w, x
                     clear_h, clear_y = h, y
                     if code == 'WRD' and wall in (0, 2) and w > 1:
@@ -3499,6 +3503,8 @@ class GenerateView:
             if placed:
                 x,y,w,h=placed; wall=self._infer_wall(x,y,w,h)
                 fc=p.meters_to_cells(spec['front_rec'])
+                if fc == 4:
+                    fc = 2
                 if wall in (0,2) and w>1:
                     clear_w = w-1
                     clear_x = x+0.5
@@ -3925,6 +3931,8 @@ class GenerateView:
                 fc_m = FRONT_REC_DEFAULT.get(code, 0.0)
                 if fc_m > 0.0:
                     fc = best.meters_to_cells(fc_m)
+                    if code == 'WRD' and fc == 4:
+                        fc = 2
                     clear_w, clear_x = w, x
                     clear_h, clear_y = h, y
                     if code == 'WRD' and wall in (0, 2) and w > 1:


### PR DESCRIPTION
## Summary
- Clamp wardrobe front clearances from four to two cells in wall unit placement and interactive add/remove helpers
- Ensure sticky item reapplications also enforce two-cell wardrobe clearance

## Testing
- `pytest -q`
- `python - <<'PY'
import random
from vastu_all_in_one import GridPlan, Openings, BedroomSolver

p = GridPlan(4.0, 4.0)
op = Openings(p)
solver = BedroomSolver(p, op, bed_key=None, rng=random.Random(0), weights={})
solver._place_wall_unit(p, 'WRD')
cz = p.clearzones[0]
print('clearzone:', cz)
print('depth', min(cz[2], cz[3]))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a8a85aa7f083308e5393078459bc81