### PR TITLE
Integrate living room rules into cell size calculation

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -9,6 +9,7 @@ from ui.overlays import ColumnGridOverlay
 
 BED_RULES_FILE = os.path.join(os.path.dirname(__file__), "rules.bedroom.json")
 BATH_RULES_FILE = os.path.join(os.path.dirname(__file__), "rules.bathroom.json")
+LIV_RULES_FILE = os.path.join(os.path.dirname(__file__), "rules.livingroom.json")
 
 def load_rules(path: str) -> Dict:
     """
@@ -25,6 +26,7 @@ def load_rules(path: str) -> Dict:
 
 RULES = load_rules(BED_RULES_FILE)
 BATH_RULES = load_rules(BATH_RULES_FILE)
+LIV_RULES = load_rules(LIV_RULES_FILE)
 
 """
 VASTU – Sketch + Generate (Bedroom) – ALL-IN-ONE ADVANCED – FINAL (Aug-2025)
@@ -60,14 +62,16 @@ Files (in working dir)
 
 IN_TO_M = 0.0254
 FT_TO_M = 0.3048
-# Use a single cell size for both bedroom and bathroom grids so each
+# Use a single cell size for bedroom, bathroom, and living room grids so each
 # cell represents the same physical dimension regardless of which plan
 # it belongs to.  Bedroom rules take precedence, falling back to the
-# bathroom rules (or a 0.25 m default) if unspecified.
+# bathroom then living room rules (or a 0.25 m default) if unspecified.
 BED_CELL_M = RULES.get("units", {}).get("CELL_M")
 BATH_CELL_M = BATH_RULES.get("units", {}).get("CELL_M")
-CELL_M = BED_CELL_M or BATH_CELL_M or 0.25
+LIV_CELL_M = LIV_RULES.get("units", {}).get("CELL_M")
+CELL_M = BED_CELL_M or BATH_CELL_M or LIV_CELL_M or 0.25
 BATH_RULES.setdefault("units", {})["CELL_M"] = CELL_M
+LIV_RULES.setdefault("units", {})["CELL_M"] = CELL_M
 PATH_WIDTH_CELLS = RULES.get("solver", {}).get("PATH_WIDTH_CELLS", 2)
 LEARNING_RATE = RULES.get("learning", {}).get("LEARNING_RATE", 0.06)
 


### PR DESCRIPTION
## Summary
- load living room rules file and include in unit calculations
- propagate cell size across bedroom, bathroom, and living room rule sets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8aedc08d4833092c23dd26f51a1da