### PR TITLE
Add living room layout support

### DIFF
--- a/tests/test_ruler_labels.py
+++ b/tests/test_ruler_labels.py
@@ -58,6 +58,7 @@ def test_ruler_labels_persist_across_zoom():
     gv = GenerateView.__new__(GenerateView)
     gv.bed_plan = plan
     gv.bath_plan = None
+    gv.liv_plan = None
     gv.plan = plan
     gv.bed_openings = Openings(plan)
     gv.bath_openings = None


### PR DESCRIPTION
## Summary
- support living-room furniture via new `LIV_CODES`
- generate and merge living room layouts with door/window controls
- enable dragging and testing of living room items

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b2c846e48330bf7d7278178dd8e7