### PR TITLE
Handle living room drag operations

### DIFF
--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -462,6 +462,8 @@ def setup_drag_view(include_liv=False):
     gv.selected_locked = False
     gv.ox = gv.oy = 0
     gv.scale = 1
+    gv.undo_stack = []
+    gv.redo_stack = []
     return gv
 
 
@@ -507,7 +509,7 @@ def test_on_up_updates_only_liv_plan():
         'orig': [xoff, 0, 1, 1],
         'live': [xoff + 1, 0, 1, 1],
         'code': 'SOFA',
-        'room': 'liv',
+        'room': 'living',
         'ghost': None,
     }
     GenerateView._on_up(gv, type('E', (), {})())


### PR DESCRIPTION
## Summary
- Recognize living room components during drag start and route movement to `liv_plan`
- Track drag operations with undo/redo stacks and unified `_commit_drag`
- Include living room plan in grid logging and update tests accordingly

## Testing
- `pytest tests/test_generate_view.py::test_on_up_updates_only_liv_plan -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b60f394c8330b9ab4cb38d2f414d