### PR TITLE
feat: support living room inputs in generator UI

### DIFF
--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -452,7 +452,7 @@ def test_init_schedules_solver(monkeypatch):
             pass
 
     root = DummyRoot()
-    gv = vastu_all_in_one.GenerateView(root, 4.0, 4.0, None, bath_dims=None)
+    gv = vastu_all_in_one.GenerateView(root, 4.0, 4.0, None, bath_dims=None, liv_dims=None)
     assert root.after_idle_called_with == gv._solve_and_draw
 
 


### PR DESCRIPTION
## Summary
- add living room section to combined area dialog
- plumb living room dimensions through startup flow and workspace open
- update tests to exercise optional living room dimensions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8ba27371883308cf53f4ee1b053d9