### PR TITLE
Ensure living room grid spans bedroom and bathroom width

### DIFF
--- a/tests/test_full_layout_contact.py
+++ b/tests/test_full_layout_contact.py
@@ -58,6 +58,30 @@ def test_combined_plan_living_contact():
     assert gv.bath_liv_openings.door_wall == WALL_BOTTOM
 
 
+def test_living_room_resizes_for_full_adjacency():
+    gv = make_generate_view((2.0, 2.0), living_dims=(5.0, 2.0))
+    gv.bed_plan = GridPlan(gv.bed_Wm, gv.bed_Hm)
+    gv.bath_plan = GridPlan(gv.bath_Wm, gv.bath_Hm)
+    gv.plan = GridPlan(
+        gv.bed_Wm + gv.bath_Wm + gv.liv_Wm,
+        max(gv.bed_Hm, gv.bath_Hm) + gv.liv_Hm,
+    )
+    gv._apply_openings_from_ui = _alignment_stub_factory(gv)
+
+    gv.bed_openings.door_wall = WALL_BOTTOM
+    gv.bath_openings.door_wall = WALL_LEFT
+    gv.bath_liv_openings.door_wall = WALL_BOTTOM
+
+    assert gv._apply_openings_from_ui()
+
+    GenerateView._combine_plans(gv)
+
+    top_gh = max(gv.bed_plan.gh, gv.bath_plan.gh)
+    assert gv.liv_plan.gw == gv.bed_plan.gw + gv.bath_plan.gw
+    for x in range(gv.bed_plan.gw + gv.bath_plan.gw):
+        assert gv.plan.occ[top_gh][x] is None
+
+
 def test_bedroom_door_misaligned():
     gv = make_generate_view((2.0, 2.0), living_dims=(6.0, 2.0))
     gv._apply_openings_from_ui = _alignment_stub_factory(gv)

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -4270,19 +4270,30 @@ class GenerateView:
         plans = [self.bed_plan]
         has_bath = bool(self.bath_plan)
         has_liv = bool(getattr(self, 'liv_plan', None))
+
+        # Width of the rooms on the top row (bedroom + optional bathroom)
+        top_width = self.bed_plan.gw + (self.bath_plan.gw if has_bath else 0)
+
         if has_bath:
             plans.append(self.bath_plan)
         if has_liv:
+            # Ensure the living room grid spans the full width of the rooms above
+            if self.liv_plan.gw < top_width:
+                new_liv = GridPlan(top_width * self.liv_plan.cell, self.liv_Hm)
+                for j in range(self.liv_plan.gh):
+                    for i in range(self.liv_plan.gw):
+                        new_liv.occ[j][i] = self.liv_plan.occ[j][i]
+                new_liv.clearzones.extend(self.liv_plan.clearzones)
+                self.liv_plan = new_liv
             plans.append(self.liv_plan)
         if len(plans) == 1:
             self.plan = self.bed_plan
             return
 
-        top_gw = self.bed_plan.gw + (self.bath_plan.gw if has_bath else 0)
         top_gh = max(self.bed_plan.gh, self.bath_plan.gh if has_bath else 0)
         liv_gw = self.liv_plan.gw if has_liv else 0
         liv_gh = self.liv_plan.gh if has_liv else 0
-        total_gw = max(top_gw, liv_gw)
+        total_gw = max(top_width, liv_gw)
         total_gh = top_gh + liv_gh
         col_grid = ColumnGrid(total_gw, total_gh)
 


### PR DESCRIPTION
## Summary
- Expand living-room GridPlan to match combined bedroom+bath width
- Offset living plan at top edge with bedroom and bathroom while preserving other offsets
- Add regression test confirming living plan enlarges to expose adjacency cells beneath both rooms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8cf88b7988330961c7f0b10f1a95f