### PR TITLE
Fix plan combination grid sizing and add regression test

### DIFF
--- a/tests/test_combine_plans.py
+++ b/tests/test_combine_plans.py
@@ -1,0 +1,23 @@
+import pytest
+
+from vastu_all_in_one import GenerateView, GridPlan, CELL_M
+
+
+def test_combine_plans_handles_offsets_without_index_error():
+    side = CELL_M * 1.5  # produces a 2x2 grid with rounding
+    gv = GenerateView.__new__(GenerateView)
+
+    # Per-room plans with non-integral metre dimensions
+    gv.bed_plan = GridPlan(side, side)
+    gv.bath_plan = GridPlan(side, side)
+    gv.liv_plan = GridPlan(side, side)
+
+    # Place items at the furthest cells to ensure indexing occurs at offsets
+    gv.bed_plan.place(gv.bed_plan.gw - 1, 0, 1, 1, "BED")
+    gv.bath_plan.place(gv.bath_plan.gw - 1, 0, 1, 1, "WC")
+    gv.liv_plan.place(0, gv.liv_plan.gh - 1, 1, 1, "SOFA")
+
+    try:
+        GenerateView._combine_plans(gv)
+    except IndexError:
+        pytest.fail("_combine_plans raised IndexError")

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -4333,12 +4333,16 @@ class GenerateView:
             self.liv_plan.x_offset = 0
             self.liv_plan.y_offset = top_gh
 
-        total_wm = max(
-            self.bed_Wm + (self.bath_Wm if has_bath else 0),
-            self.liv_Wm if has_liv else 0,
-        )
-        total_hm = max(self.bed_Hm, self.bath_Hm if has_bath else 0)
-        total_hm += self.liv_Hm if has_liv else 0
+        # ``GridPlan`` derives its internal grid dimensions from the supplied
+        # physical size (``Wm``/``Hm``).  When the per-room plans use widths or
+        # heights that are not exact multiples of ``CELL_M`` this can lead to
+        # rounding differences: the summed metres may produce a grid that is
+        # smaller than the total number of columns/rows we intend to index.
+        # Derive the combined physical dimensions directly from the desired
+        # grid dimensions so that ``combined.occ`` is guaranteed to be large
+        # enough for all offsets.
+        total_wm = total_gw * CELL_M
+        total_hm = total_gh * CELL_M
 
         combined = GridPlan(total_wm, total_hm, column_grid=col_grid)
         for p in plans:


### PR DESCRIPTION
## Summary
- Fix grid-based plan combination to derive dimensions from cell counts, preventing rounding errors that led to `IndexError`
- Add regression test ensuring `_combine_plans` handles bedroom/bathroom/living-room offsets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bfe98e954883309c6fe4f97f5dc8d6