### PR TITLE
Standardize door and window opening colors

### DIFF
--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -21,6 +21,7 @@ from vastu_all_in_one import (
     opposite_wall,
     CELL_M,
     DOOR_FILL,
+    WINDOW_FILL,
 )
 from ui.overlays import ColumnGridOverlay, LegendPopover
 
@@ -679,6 +680,7 @@ def test_door_rectangle_present(monkeypatch):
         if i.get('fill') == DOOR_FILL and 'opening' in i.get('tags', ())
     ]
     assert door_items, 'Door rectangle not found'
+    assert all(i.get('outline') == 'black' for i in door_items)
 
 
 def test_opening_popover_shows_details(monkeypatch):
@@ -772,9 +774,12 @@ def test_opening_popover_shows_details(monkeypatch):
     window_id = None
     for item in gv.canvas.find_withtag('opening'):
         fill = gv.canvas.itemcget(item, 'fill')
+        outline = gv.canvas.itemcget(item, 'outline')
+        assert outline == 'black'
         if fill == DOOR_FILL:
             door_id = item
         else:
+            assert fill == WINDOW_FILL
             window_id = item
 
     assert door_id is not None and window_id is not None

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -2650,11 +2650,12 @@ ITEM_LABELS = {
 
 
 WALL_COLOR='#000000'
-WIN_COLOR='#000000'
 
-# Use a brighter fill so doors stand out from black walls
+# Use a brighter fill so doors stand out from black walls and keep window
+# fill distinct.  Expose them as module-level constants so tests can refer to
+# them directly.
 DOOR_FILL='#ff8c00'
-WIN_FILL='#95c8ff'
+WINDOW_FILL='#95c8ff'
 
 HUMAN1_COLOR='#ff6262'
 HUMAN2_COLOR='#ffdd55'
@@ -3897,7 +3898,7 @@ class GenerateView:
                 y0,
                 x1,
                 y1,
-                outline=WALL_COLOR,
+                outline='black',
                 width=open_width,
                 fill=fill_color,
                 tags=('plan', 'opening'),
@@ -3918,7 +3919,7 @@ class GenerateView:
             seg(dwall, dstart, dwidth, DOOR_FILL, 'door')
 
         for wall, start, length in openings.window_spans_cells():
-            seg(wall, start, length, WIN_FILL, 'window')
+            seg(wall, start, length, WINDOW_FILL, 'window')
 
     def _draw_opening_segment(self, cv, wall, start, length, color, width):
         if wall<0 or length<=0: return


### PR DESCRIPTION
## Summary
- Centralize DOOR_FILL and WINDOW_FILL constants for openings
- Draw room openings with black outlines and consistent door/window colors
- Extend rendering tests to check door/window fill and outline colors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bffc8165b883308e3ba735659cc1ae