### PR TITLE
Avoid default living-room window and add regression test

### DIFF
--- a/tests/test_arrange_livingroom.py
+++ b/tests/test_arrange_livingroom.py
@@ -4,7 +4,7 @@ import pytest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from vastu_all_in_one import arrange_livingroom, LIV_RULES
+from vastu_all_in_one import arrange_livingroom, LIV_RULES, GridPlan, Openings
 
 
 def _find_rect(plan, code):
@@ -62,4 +62,13 @@ def test_arrange_livingroom_partial_plan_when_space_limited():
 
     assert _find_rect(plan, "SOFA") is None
     assert _find_rect(plan, "CTAB") is not None
+
+
+def test_arrange_livingroom_no_default_windows_when_unspecified():
+    base = GridPlan(5.0, 4.0)
+    openings = Openings(base)
+    plan = arrange_livingroom(5.0, 4.0, LIV_RULES, openings=openings)
+
+    assert openings.window_spans_cells() == []
+    assert all(owner != 'WINDOW' for *_, owner in plan.clearzones)
 

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -2564,6 +2564,13 @@ def arrange_livingroom(
 
     p = GridPlan(Wm, Hm)
     if openings:
+        # ``Openings`` seeds each plan with a placeholder window.  For the
+        # living room we don't want any implicit windows—only those the user
+        # explicitly defined or that come from rule configuration.  When the
+        # default placeholder is present (two entries with the second marked by
+        # a negative wall index) clear the list so no window is assumed.
+        if len(openings.windows) == 2 and openings.windows[1][0] < 0:
+            openings.windows = []
         dx, dy, dw, dh = openings.door_rect_cells()
         if p.fits(dx, dy, dw, dh):
             p.place(dx, dy, dw, dh, 'DOOR')


### PR DESCRIPTION
## Summary
- Remove implicit placeholder window in living-room arrangements so windows only appear when user-defined or rule-based
- Add regression test confirming no windows exist when none specified

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bffe7f733c8330895eb66e542e75c6