### PR TITLE
Add kitchen rule loading and cell size fallback

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -11,6 +11,7 @@ from ui.overlays import ColumnGridOverlay, LegendPopover
 BED_RULES_FILE = os.path.join(os.path.dirname(__file__), "rules.bedroom.json")
 BATH_RULES_FILE = os.path.join(os.path.dirname(__file__), "rules.bathroom.json")
 LIV_RULES_FILE = os.path.join(os.path.dirname(__file__), "rules.livingroom.json")
+KITCH_RULES_FILE = os.path.join(os.path.dirname(__file__), "rules.kitchen.json")
 
 def load_rules(path: str) -> Dict:
     """
@@ -28,6 +29,7 @@ def load_rules(path: str) -> Dict:
 RULES = load_rules(BED_RULES_FILE)
 BATH_RULES = load_rules(BATH_RULES_FILE)
 LIV_RULES = load_rules(LIV_RULES_FILE)
+KITCH_RULES = load_rules(KITCH_RULES_FILE)
 
 """
 VASTU – Sketch + Generate (Bedroom) – ALL-IN-ONE ADVANCED – FINAL (Aug-2025)
@@ -64,16 +66,18 @@ Files (in working dir)
 
 IN_TO_M = 0.0254
 FT_TO_M = 0.3048
-# Use a single cell size for bedroom, bathroom, and living room grids so each
+# Use a single cell size for bedroom, bathroom, living room, and kitchen grids so each
 # cell represents the same physical dimension regardless of which plan
 # it belongs to.  Bedroom rules take precedence, falling back to the
-# bathroom then living room rules (or a 0.25 m default) if unspecified.
+# bathroom then living room, then kitchen rules (or a 0.25 m default) if unspecified.
 BED_CELL_M = RULES.get("units", {}).get("CELL_M")
 BATH_CELL_M = BATH_RULES.get("units", {}).get("CELL_M")
 LIV_CELL_M = LIV_RULES.get("units", {}).get("CELL_M")
-CELL_M = BED_CELL_M or BATH_CELL_M or LIV_CELL_M or 0.25
+KITCH_CELL_M = KITCH_RULES.get("units", {}).get("CELL_M")
+CELL_M = BED_CELL_M or BATH_CELL_M or LIV_CELL_M or KITCH_CELL_M or 0.25
 BATH_RULES.setdefault("units", {})["CELL_M"] = CELL_M
 LIV_RULES.setdefault("units", {})["CELL_M"] = CELL_M
+KITCH_RULES.setdefault("units", {})["CELL_M"] = CELL_M
 PATH_WIDTH_CELLS = RULES.get("solver", {}).get("PATH_WIDTH_CELLS", 2)
 LEARNING_RATE = RULES.get("learning", {}).get("LEARNING_RATE", 0.06)
 WINDOW_CLEARANCE_M = 0.40


### PR DESCRIPTION
## Summary
- Load kitchen design rules alongside existing room rules
- Include kitchen cell size in CELL_M selection and propagate to kitchen rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c02149d9a483309093ede4728f1073