### PR TITLE
Add kitchen layout support to GenerateView

### DIFF
--- a/tests/test_combine_plans.py
+++ b/tests/test_combine_plans.py
@@ -11,11 +11,13 @@ def test_combine_plans_handles_offsets_without_index_error():
     gv.bed_plan = GridPlan(side, side)
     gv.bath_plan = GridPlan(side, side)
     gv.liv_plan = GridPlan(side, side)
+    gv.kitch_plan = GridPlan(side, side)
 
     # Place items at the furthest cells to ensure indexing occurs at offsets
     gv.bed_plan.place(gv.bed_plan.gw - 1, 0, 1, 1, "BED")
     gv.bath_plan.place(gv.bath_plan.gw - 1, 0, 1, 1, "WC")
     gv.liv_plan.place(0, gv.liv_plan.gh - 1, 1, 1, "SOFA")
+    gv.kitch_plan.place(gv.kitch_plan.gw - 1, gv.kitch_plan.gh - 1, 1, 1, "SINK")
 
     try:
         GenerateView._combine_plans(gv)


### PR DESCRIPTION
## Summary
- allow kitchen dimensions in `GenerateView` and track kitchen plan/openings
- merge kitchen plans into combined layout and drawing routines
- trigger `KitchenSolver` when kitchen dimensions are provided

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c025bd46f48330bb1e8c5f3efe1964