### PR TITLE
Add unique grid codes for kitchen appliances

### DIFF
--- a/tests/test_kitchen_codes.py
+++ b/tests/test_kitchen_codes.py
@@ -4,7 +4,13 @@ import sys
 # Ensure repository root is importable
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from vastu_all_in_one import GenerateView, PALETTE, ITEM_LABELS
+from vastu_all_in_one import (
+    GenerateView,
+    PALETTE,
+    ITEM_LABELS,
+    BedroomSolver,
+    GridPlan,
+)
 from test_generate_view import setup_drag_view
 
 
@@ -24,4 +30,25 @@ def test_kitchen_codes_and_selection():
     event = type('E', (), {'x': (x0 + x1) / 2, 'y': (y0 + y1) / 2})()
     GenerateView._on_down(gv, event)
     assert gv.selected['code'] == 'SINK'
+
+
+def test_grid_snapshot_assigns_unique_ints_to_kitchen_codes():
+    solver = BedroomSolver.__new__(BedroomSolver)
+    expected = {
+        'SINK': 7,
+        'COOK': 8,
+        'REFR': 9,
+        'DW': 10,
+        'ISLN': 11,
+        'BASE': 12,
+        'WALL': 13,
+        'HOOD': 14,
+        'OVEN': 15,
+        'MICRO': 16,
+    }
+    for code, val in expected.items():
+        plan = GridPlan(1.0, 1.0)
+        plan.place(0, 0, 1, 1, code)
+        grid = solver._grid_snapshot(plan, max_hw=1)
+        assert grid[0, 0] == val
 

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -1947,7 +1947,11 @@ class BedroomSolver:
 
     def _grid_snapshot(self, plan:'GridPlan', max_hw: int = 16):
         """Downsample occupancy to a small int grid for CNN/analytics."""
-        mapping = {'BED':1,'BST':2,'WRD':3,'DRS':4,'DESK':5,'TVU':6}
+        mapping = {
+            'BED': 1, 'BST': 2, 'WRD': 3, 'DRS': 4, 'DESK': 5, 'TVU': 6,
+            'SINK': 7, 'COOK': 8, 'REF': 9, 'REFR': 9, 'DW': 10, 'ISLN': 11,
+            'BASE': 12, 'WALL': 13, 'HOOD': 14, 'OVEN': 15, 'MICRO': 16
+        }
         H = min(max_hw, plan.gh); W = min(max_hw, plan.gw)
         sx = max(1, plan.gw // W); sy = max(1, plan.gh // H)
         G = np.zeros((H,W), dtype=np.int8)
@@ -1958,7 +1962,7 @@ class BedroomSolver:
                 c = plan.occ[y][x]
                 if c:
                     base = c.split(':')[0]
-                    G[jj,ii] = mapping.get(base,7)
+                    G[jj,ii] = mapping.get(base,17)
                 ii+=1
                 if ii>=W: break
             jj+=1
@@ -5168,7 +5172,11 @@ class GenerateView:
         append_jsonl_locked(SIM_FILE, obj)
 
     def _grid_snapshot(self, plan: 'GridPlan', max_hw: int = 16):
-        mapping = {'BED':1,'BST':2,'WRD':3,'DRS':4,'DESK':5,'TVU':6}
+        mapping = {
+            'BED': 1, 'BST': 2, 'WRD': 3, 'DRS': 4, 'DESK': 5, 'TVU': 6,
+            'SINK': 7, 'COOK': 8, 'REF': 9, 'REFR': 9, 'DW': 10, 'ISLN': 11,
+            'BASE': 12, 'WALL': 13, 'HOOD': 14, 'OVEN': 15, 'MICRO': 16
+        }
         H = min(max_hw, plan.gh); W = min(max_hw, plan.gw)
         sx = max(1, plan.gw // W); sy = max(1, plan.gh // H)
         G = np.zeros((H, W), dtype=np.int8)
@@ -5179,7 +5187,7 @@ class GenerateView:
                 c = plan.occ[y][x]
                 if c:
                     base = c.split(':')[0]
-                    G[jj, ii] = mapping.get(base, 7)
+                    G[jj, ii] = mapping.get(base, 17)
                 ii += 1
                 if ii >= W:
                     break


### PR DESCRIPTION
## Summary
- extend `_grid_snapshot` mapping to encode kitchen items with unique integers
- fallback value for unknown items now uses 17
- test ensures kitchen codes map to expected integers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0282bd58c8330a93670508cff048e