### PR TITLE
Expand room input dialog

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -1177,9 +1177,9 @@ class AreaDialogCombined(tk.Toplevel):
     def __init__(self, parent: tk.Misc, mode_label: str):
         super().__init__(parent)
         self.title('Room Inputs')
-        self.transient(parent); self.grab_set(); self.resizable(False, False)
+        self.transient(parent); self.grab_set(); self.resizable(True, True)
         self.result=None
-        w,h=640,880; self._center(parent,w,h)
+        w,h=640,1020; self._center(parent,w,h)
         f=ttk.Frame(self, padding=24); f.pack(fill=tk.BOTH, expand=True)
         ttk.Label(f, text=f'{mode_label}: set room inputs', font=('SF Pro Text', 14, 'bold')).pack(anchor='w')
 


### PR DESCRIPTION
## Summary
- Allow `AreaDialogCombined` window to be resizable
- Increase dialog size to 640x1020 and center with new dimensions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c031e2d654833082b7a195e4c602a8