### PR TITLE
Handle kitchen adjacency failure gracefully

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -3681,9 +3681,13 @@ class GenerateView:
                 and kitch_plan.y_offset == liv_plan.y_offset == top_gh
                 and liv_plan.gw == left_gw
             ):
-                raise ValueError(
+                # Inform user of invalid adjacency and revert without drawing
+                self.status.set(
                     "Kitchen must be adjacent to both bathroom and living room"
                 )
+                if prev_plan is not None:
+                    self.plan = prev_plan
+                return
 
         if bath_plan and bath_ext:
             bx, by, bw, bh = bath_ext


### PR DESCRIPTION
## Summary
- Prevent crash when kitchen adjacency validation fails
- Restore previous layout and display user-facing status instead of raising

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c038bcbb388330a46f279054b4e662