### PR TITLE
Handle missing furn items when adjusting canvas layers

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -4061,8 +4061,12 @@ class GenerateView:
             room_name,
         )
         cv.tag_lower('clear')
-        cv.tag_raise('furn', 'clear')
-        cv.tag_raise('room', 'furn')
+        has_furn = bool(getattr(cv, 'find_withtag', lambda _tag: [])('furn'))
+        if has_furn:
+            cv.tag_raise('furn', 'clear')
+            cv.tag_raise('room', 'furn')
+        else:
+            cv.tag_raise('room')
         cv.tag_raise('opening', 'room')
 
     def _draw_clearances(self, cv, plan, openings, ox, oy, scale):


### PR DESCRIPTION
## Summary
- guard canvas layer adjustments by checking for furniture items
- raise room layer without reference when no furniture is present

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c038d31d28833084002423c6403c80