### PR TITLE
Consider living room width when combining plans

### DIFF
--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -3643,7 +3643,7 @@ class GenerateView:
             else:
                 kitch_plan = None
 
-        left_gw = bed_plan.gw
+        left_gw = max(bed_plan.gw, liv_plan.gw if liv_plan else 0)
         right_gw = max(
             bath_plan.gw if bath_plan else 0,
             kitch_plan.gw if kitch_plan else 0,
@@ -4789,7 +4789,7 @@ class GenerateView:
         # Arrange plans in a 2x2 grid:
         # [bed][bath]
         # [liv][kitch]
-        left_gw = self.bed_plan.gw
+        left_gw = max(self.bed_plan.gw, self.liv_plan.gw if has_liv else 0)
         right_gw = max(
             self.bath_plan.gw if has_bath else 0,
             self.kitch_plan.gw if has_kitch else 0,


### PR DESCRIPTION
## Summary
- adjust `left_gw` to consider living room width during layout assembly
- mirror `left_gw` calculation in `_combine_plans`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c03e4960b08330a1c98f1c7fe0b7d4