### PR TITLE
Detect and prevent overlapping room plans

### DIFF
--- a/tests/test_overlaps.py
+++ b/tests/test_overlaps.py
@@ -1,0 +1,17 @@
+from vastu_all_in_one import overlaps
+
+
+class Dummy:
+    def __init__(self, x, y, w, h):
+        self.x_offset = x
+        self.y_offset = y
+        self.gw = w
+        self.gh = h
+
+
+def test_overlaps_true_and_false():
+    a = Dummy(0, 0, 2, 2)
+    b = Dummy(1, 1, 2, 2)
+    c = Dummy(2, 2, 2, 2)
+    assert overlaps(a, b)
+    assert not overlaps(a, c)


### PR DESCRIPTION
## Summary
- add `overlaps` helper to detect intersecting room rectangles
- abort plan combination when any rooms overlap to avoid invalid layouts
- cover helper with unit test

## Testing
- `pip install numpy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0400b78308330911d657becd60a0a