### PR TITLE
Add required furniture validation and tests

### DIFF
--- a/tests/test_full_layout_contact.py
+++ b/tests/test_full_layout_contact.py
@@ -40,7 +40,9 @@ def _alignment_stub_factory(gv):
 def test_combined_plan_living_contact():
     gv = make_generate_view((2.0, 2.0), living_dims=(6.0, 2.0))
     gv.bed_plan = GridPlan(gv.bed_Wm, gv.bed_Hm)
+    gv.bed_plan.place(0, 0, 1, 1, 'BED')
     gv.bath_plan = GridPlan(gv.bath_Wm, gv.bath_Hm)
+    gv.liv_plan.place(0, 0, 1, 1, 'SOFA')
     gv.plan = GridPlan(gv.bed_Wm + gv.bath_Wm + gv.liv_Wm, max(gv.bed_Hm, gv.bath_Hm) + gv.liv_Hm)
     gv._apply_openings_from_ui = _alignment_stub_factory(gv)
 
@@ -137,6 +139,15 @@ def test_living_invalid_without_shared_door(monkeypatch):
     gv.bath_liv_openings = None
     gv.liv_bath_openings = None
 
+    class DummyBedroomSolver:
+        def __init__(self, plan, *a, **k):
+            self.plan = plan
+
+        def run(self):
+            self.plan.place(0, 0, 1, 1, 'BED')
+            return self.plan, {}
+
+    monkeypatch.setattr(vastu_all_in_one, 'BedroomSolver', DummyBedroomSolver)
     monkeypatch.setattr(
         vastu_all_in_one, 'arrange_bathroom', lambda *a, **k: GridPlan(*gv.bath_dims)
     )

--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -597,6 +597,7 @@ def test_bedroom_door_drawn_with_bathroom(monkeypatch):
             self.plan = plan
 
         def run(self):
+            self.plan.place(0, 0, 1, 1, 'BED')
             return self.plan, {'score': 1.0, 'coverage': 0.5, 'paths_ok': True, 'reach_windows': True}
 
     def dummy_arrange_bathroom(w, h, rules, openings=None, secondary_openings=None, rng=None):
@@ -645,6 +646,7 @@ def test_door_rectangle_present(monkeypatch):
             self.plan = plan
 
         def run(self):
+            self.plan.place(0, 0, 1, 1, 'BED')
             return self.plan, {
                 'score': 1.0,
                 'coverage': 0.5,
@@ -694,6 +696,7 @@ def test_opening_click_opens_dialog(monkeypatch):
             self.plan = plan
 
         def run(self):
+            self.plan.place(0, 0, 1, 1, 'BED')
             return self.plan, {
                 'score': 1.0,
                 'coverage': 0.5,
@@ -821,6 +824,7 @@ def test_bath_living_door_drawn_and_mirrored(monkeypatch):
             self.plan = plan
 
         def run(self):
+            self.plan.place(0, 0, 1, 1, 'BED')
             return self.plan, {'score': 1.0, 'coverage': 0.5, 'paths_ok': True, 'reach_windows': True}
 
     def dummy_arrange_bathroom(w, h, rules, openings=None, secondary_openings=None, rng=None):
@@ -1134,6 +1138,7 @@ def test_opening_dialog_prepopulates_values(monkeypatch):
             self.plan = plan
 
         def run(self):
+            self.plan.place(0, 0, 1, 1, 'BED')
             return self.plan, {
                 'score': 1.0,
                 'coverage': 0.5,

--- a/tests/test_required_furniture.py
+++ b/tests/test_required_furniture.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import pytest
+
+# Ensure repository root is importable
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from vastu_all_in_one import (
+    GenerateView,
+    GridPlan,
+    WALL_RIGHT,
+)
+from test_generate_view import setup_drag_view, make_generate_view
+
+
+def test_generated_plan_contains_required_furniture():
+    gv = setup_drag_view(include_liv=True, include_kitch=True)
+    gv.bed_plan.place(0, 0, 1, 1, 'BED')
+    gv.bath_plan.place(0, 0, 1, 1, 'WC')
+    gv.liv_plan.place(0, 0, 1, 1, 'SOFA')
+    gv.kitch_plan.place(0, 0, 1, 1, 'SINK')
+    GenerateView._combine_plans(gv)
+    codes = {c for row in gv.plan.occ for c in row if c}
+    assert {'BED', 'SOFA', 'SINK', 'WC'} <= codes
+
+
+def test_missing_bed_raises(monkeypatch):
+    import vastu_all_in_one
+
+    class DummyBedroomSolver:
+        def __init__(self, plan, *args, **kwargs):
+            self.plan = plan
+
+        def run(self):
+            return self.plan, {}
+
+    monkeypatch.setattr(vastu_all_in_one, 'BedroomSolver', DummyBedroomSolver)
+
+    gv = make_generate_view()
+    gv.bed_openings.door_wall = WALL_RIGHT
+    gv._apply_openings_from_ui = lambda: True
+
+    with pytest.raises(ValueError):
+        gv._solve_and_draw()


### PR DESCRIPTION
## Summary
- ensure bedroom and kitchen plans include required furniture before merging
- skip merging of room plans missing required items
- add regression tests covering furniture presence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c04b4fc80c8330b400ad3a74e4b2a9