### PR TITLE
refactor: centralize grid code mapping

### DIFF
--- a/tests/test_kitchen_codes.py
+++ b/tests/test_kitchen_codes.py
@@ -10,6 +10,7 @@ from vastu_all_in_one import (
     ITEM_LABELS,
     BedroomSolver,
     GridPlan,
+    GRID_CODE_MAPPING,
 )
 from test_generate_view import setup_drag_view
 
@@ -32,8 +33,9 @@ def test_kitchen_codes_and_selection():
     assert gv.selected['code'] == 'SINK'
 
 
-def test_grid_snapshot_assigns_unique_ints_to_kitchen_codes():
+def test_grid_code_mapping_and_snapshots_consistent():
     solver = BedroomSolver.__new__(BedroomSolver)
+    view = GenerateView.__new__(GenerateView)
     expected = {
         'SINK': 7,
         'COOK': 8,
@@ -46,9 +48,17 @@ def test_grid_snapshot_assigns_unique_ints_to_kitchen_codes():
         'OVEN': 15,
         'MICRO': 16,
     }
+    # Ensure the module-level mapping contains all kitchen codes with expected values
+    for code, val in expected.items():
+        assert GRID_CODE_MAPPING[code] == val
+
+    # Both snapshot implementations should reference the same mapping
     for code, val in expected.items():
         plan = GridPlan(1.0, 1.0)
         plan.place(0, 0, 1, 1, code)
-        grid = solver._grid_snapshot(plan, max_hw=1)
-        assert grid[0, 0] == val
+        grid_solver = solver._grid_snapshot(plan, max_hw=1)
+        grid_view = view._grid_snapshot(plan, max_hw=1)
+        assert grid_solver[0, 0] == val
+        assert grid_view[0, 0] == val
+        assert grid_solver[0, 0] == grid_view[0, 0]
 

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -32,6 +32,17 @@ BATH_RULES = load_rules(BATH_RULES_FILE)
 LIV_RULES = load_rules(LIV_RULES_FILE)
 KITCH_RULES = load_rules(KITCH_RULES_FILE)
 
+# Mapping of plan item codes to the integer values used in grid snapshots.
+#
+# These integers are consumed by various analytics routines and must remain
+# consistent across all snapshot implementations.  Bedroom furniture occupies
+# the range 1–6 while kitchen modules use 7–16.
+GRID_CODE_MAPPING = {
+    'BED': 1, 'BST': 2, 'WRD': 3, 'DRS': 4, 'DESK': 5, 'TVU': 6,
+    'SINK': 7, 'COOK': 8, 'REF': 9, 'DW': 10, 'ISLN': 11,
+    'BASE': 12, 'WALL': 13, 'HOOD': 14, 'OVEN': 15, 'MICRO': 16,
+}
+
 """
 VASTU – Sketch + Generate (Bedroom) – ALL-IN-ONE ADVANCED – FINAL (Aug-2025)
 
@@ -1971,11 +1982,7 @@ class BedroomSolver:
 
     def _grid_snapshot(self, plan:'GridPlan', max_hw: int = 16):
         """Downsample occupancy to a small int grid for CNN/analytics."""
-        mapping = {
-            'BED': 1, 'BST': 2, 'WRD': 3, 'DRS': 4, 'DESK': 5, 'TVU': 6,
-            'SINK': 7, 'COOK': 8, 'REF': 9, 'DW': 10, 'ISLN': 11,
-            'BASE': 12, 'WALL': 13, 'HOOD': 14, 'OVEN': 15, 'MICRO': 16
-        }
+        mapping = GRID_CODE_MAPPING
         H = min(max_hw, plan.gh); W = min(max_hw, plan.gw)
         sx = max(1, plan.gw // W); sy = max(1, plan.gh // H)
         G = np.zeros((H,W), dtype=np.int8)
@@ -5476,11 +5483,7 @@ class GenerateView:
         append_jsonl_locked(SIM_FILE, obj)
 
     def _grid_snapshot(self, plan: 'GridPlan', max_hw: int = 16):
-        mapping = {
-            'BED': 1, 'BST': 2, 'WRD': 3, 'DRS': 4, 'DESK': 5, 'TVU': 6,
-            'SINK': 7, 'COOK': 8, 'REF': 9, 'DW': 10, 'ISLN': 11,
-            'BASE': 12, 'WALL': 13, 'HOOD': 14, 'OVEN': 15, 'MICRO': 16
-        }
+        mapping = GRID_CODE_MAPPING
         H = min(max_hw, plan.gh); W = min(max_hw, plan.gw)
         sx = max(1, plan.gw // W); sy = max(1, plan.gh // H)
         G = np.zeros((H, W), dtype=np.int8)


### PR DESCRIPTION
## Summary
- centralize furniture and appliance code to integer mapping via `GRID_CODE_MAPPING`
- update both grid snapshot helpers to use shared mapping
- add regression test validating mapping consistency across snapshots

## Testing
- `pip install numpy -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c05c484e688330b685d8cb2d4060ee