### PR TITLE
Compute kitchen work triangle bonus from appliance spacing

### DIFF
--- a/tests/test_kitchen_solver.py
+++ b/tests/test_kitchen_solver.py
@@ -20,16 +20,29 @@ def test_default_sets_include_work_triangle():
 
 
 def test_solver_reports_triangle_bonus():
-    plan = GridPlan(3.0, 3.0)
+    plan = GridPlan(8.0, 8.0)
     plan.place(0, 0, 1, 1, 'SINK')
-    plan.place(2, 0, 1, 1, 'COOK')
-    plan.place(0, 2, 1, 1, 'REF')
+    plan.place(8, 0, 1, 1, 'COOK')
+    plan.place(0, 8, 1, 1, 'REF')
     openings = Openings(plan)
     solver = KitchenSolver(plan, openings, rng=random.Random(0), weights={})
     result, meta = solver.run(appliance_sets=[('SINK', 'COOK', 'REF')])
     assert result is not None
     feats = meta.get('features', {})
     assert feats.get('work_triangle_bonus', 0.0) == 1.0
+
+
+def test_work_triangle_bonus_drops_when_appliances_far():
+    plan = GridPlan(8.0, 8.0)
+    plan.place(0, 0, 1, 1, 'SINK')
+    plan.place(8, 0, 1, 1, 'COOK')
+    plan.place(0, 20, 1, 1, 'REF')
+    openings = Openings(plan)
+    solver = KitchenSolver(plan, openings, rng=random.Random(0), weights={})
+    result, meta = solver.run(appliance_sets=[('SINK', 'COOK', 'REF')])
+    assert result is not None
+    feats = meta.get('features', {})
+    assert feats.get('work_triangle_bonus', 1.0) == 0.0
 
 
 def test_solver_fills_missing_appliances():


### PR DESCRIPTION
## Summary
- compute sink, cooktop, and refrigerator center distances and reward perimeter between 4–7 meters
- document work triangle criteria in `_work_triangle_bonus`
- verify bonus falls to 0 when an appliance is moved beyond the optimal range

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c05e8cf2b883308fe6050aa90f4a6a