### PR TITLE
Add adjacency score threshold to solvers

### DIFF
--- a/tests/test_bedroom_solver.py
+++ b/tests/test_bedroom_solver.py
@@ -41,6 +41,16 @@ def test_solver_custom_set_fallback():
     assert counts['BED'] == 1
 
 
+def test_solver_respects_min_adjacency_threshold():
+    plan = GridPlan(3.0, 3.0)
+    openings = Openings(plan)
+    solver = BedroomSolver(plan, openings, bed_key=None, rng=random.Random(0), weights={})
+    result, meta = solver.run(iters=80, time_budget_ms=200, max_attempts=2, min_adjacency=10.0)
+    assert result is None
+    assert meta.get('status') == 'adjacency_below_threshold'
+    assert meta.get('features', {}).get('adjacency', 0.0) < 10.0
+
+
 def test_mark_clear_removes_entire_bed():
     plan = GridPlan(3.0, 3.0)
     plan.place(0, 0, 2, 1, 'BED:1')

--- a/tests/test_kitchen_solver.py
+++ b/tests/test_kitchen_solver.py
@@ -66,6 +66,16 @@ def test_solver_score_uses_dot_product_only():
     assert math.isclose(meta.get('score'), expected)
 
 
+def test_solver_respects_min_adjacency_threshold():
+    plan = GridPlan(3.0, 3.0)
+    openings = Openings(plan)
+    solver = KitchenSolver(plan, openings, rng=random.Random(0), weights={})
+    result, meta = solver.run(appliance_sets=[('SINK', 'COOK', 'REF')], min_adjacency=10.0, iters=20, time_budget_ms=200)
+    assert result is None
+    assert meta.get('status') == 'adjacency_below_threshold'
+    assert meta.get('features', {}).get('adjacency', 0.0) < 10.0
+
+
 def test_custom_book_clear_override():
     plan = GridPlan(2.0, 2.0)
     openings = Openings(plan)


### PR DESCRIPTION
## Summary
- Track adjacency for each candidate in BedroomSolver and iterate until perfect adjacency or search limits
- Add minimum adjacency threshold to solvers and return layout only when met
- Cover adjacency threshold behavior with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c066ca595c8330a93a8ab2be2b4774