### PR TITLE
Allow kitchen-living separation with bathroom adjacency

### DIFF
--- a/tests/test_adjacency_message.py
+++ b/tests/test_adjacency_message.py
@@ -96,10 +96,11 @@ def test_kitchen_adjacency_failure_sets_status(monkeypatch):
 
     monkeypatch.setattr(vastu_all_in_one, "arrange_bathroom", dummy_arrange_bathroom)
     monkeypatch.setattr(vastu_all_in_one, "arrange_livingroom", dummy_arrange_livingroom)
+    monkeypatch.setattr(vastu_all_in_one, "shares_edge", lambda a, b: False)
 
     gv._solve_and_draw()
     assert (
         gv.status.msg
-        == "Kitchen must share an edge with BOTH Living and Bathroom. Currently it does not."
+        == "Kitchen must share a wall with the Bathroom. Currently it does not."
     )
 

--- a/tests/test_kitchen_bath_living_indirect.py
+++ b/tests/test_kitchen_bath_living_indirect.py
@@ -1,0 +1,114 @@
+import os
+import os
+import sys
+import tkinter as tk
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from vastu_all_in_one import (
+    GenerateView,
+    GridPlan,
+    Openings,
+    CELL_M,
+    shares_edge,
+    WALL_LEFT,
+    WALL_RIGHT,
+    WALL_BOTTOM,
+    WALL_TOP,
+)
+from test_generate_view import DummyStatus, DummyRoot
+
+
+def make_gv():
+    master = tk.Tcl()
+    tk._default_root = master
+    gv = GenerateView.__new__(GenerateView)
+    gv.status = DummyStatus()
+    gv.root = DummyRoot()
+    gv.sim_timer = gv.sim2_timer = None
+    gv.sim_path = gv.sim_poly = gv.sim2_path = gv.sim2_poly = []
+    gv._draw = lambda: None
+    gv._log_run = lambda meta: None
+    gv.bed_key = None
+    gv.mlp = gv.transformer = None
+    gv.force_bst_pair = type("V", (), {"get": lambda self: False})()
+    return gv
+
+
+def test_indirect_living_connection(monkeypatch):
+    gv = make_gv()
+    cell = CELL_M
+    gv.bed_Wm = 2 * cell
+    gv.bed_Hm = cell
+    gv.bath_dims = (cell, cell)
+    gv.bath_Wm = gv.bath_Hm = cell
+    gv.liv_dims = (cell, cell)
+    gv.liv_Wm = gv.liv_Hm = cell
+    gv.kitch_dims = (cell, cell)
+    gv.kitch_Wm = gv.kitch_Hm = cell
+
+    gv.bed_openings = Openings(GridPlan(gv.bed_Wm, gv.bed_Hm))
+    gv.bed_openings.swing_depth = cell
+    gv.bed_openings.door_wall = WALL_RIGHT
+    gv.bed_openings.door_center = cell / 2
+    gv.bed_openings.door_width = cell
+    gv.bath_openings = Openings(GridPlan(*gv.bath_dims))
+    gv.bath_openings.swing_depth = cell
+    gv.bath_openings.door_wall = WALL_LEFT
+    gv.bath_openings.door_center = cell / 2
+    gv.bath_openings.door_width = cell
+    gv.liv_openings = Openings(GridPlan(*gv.liv_dims))
+    gv.liv_openings.swing_depth = cell
+    gv.liv_openings.door_wall = WALL_TOP
+    gv.liv_openings.door_center = cell / 2
+    gv.liv_openings.door_width = cell
+    gv.kitch_openings = None
+    gv.bath_liv_openings = Openings(GridPlan(*gv.bath_dims))
+    gv.bath_liv_openings.swing_depth = cell
+    gv.bath_liv_openings.door_wall = WALL_BOTTOM
+    gv.bath_liv_openings.door_center = cell / 2
+    gv.bath_liv_openings.door_width = cell
+    gv.liv_bath_openings = Openings(GridPlan(*gv.liv_dims))
+    gv.liv_bath_openings.swing_depth = cell
+    gv.liv_bath_openings.door_wall = WALL_TOP
+    gv.liv_bath_openings.door_center = cell / 2
+    gv.liv_bath_openings.door_width = cell
+
+    gv._apply_openings_from_ui = lambda: True
+
+    class DummyBedroomSolver:
+        def __init__(self, plan, *a, **k):
+            self.plan = plan
+        def run(self):
+            self.plan.place(0, 0, 1, 1, 'BED')
+            return self.plan, {"score": 1.0}
+
+    class DummyKitchenSolver:
+        def __init__(self, plan, *a, **k):
+            self.plan = plan
+        def run(self):
+            self.plan.place(0, 0, 1, 1, 'SINK')
+            return self.plan, None
+
+    def dummy_arrange_bathroom(w, h, rules, openings=None, secondary_openings=None):
+        p = GridPlan(w, h)
+        p.place(0, 0, 1, 1, 'WC')
+        return p
+
+    def dummy_arrange_livingroom(w, h, rules, openings=None):
+        p = GridPlan(w, h)
+        p.place(0, 0, 1, 1, 'SOFA')
+        return p
+
+    import vastu_all_in_one
+    monkeypatch.setattr(vastu_all_in_one, 'BedroomSolver', DummyBedroomSolver)
+    monkeypatch.setattr(vastu_all_in_one, 'KitchenSolver', DummyKitchenSolver)
+    monkeypatch.setattr(vastu_all_in_one, 'arrange_bathroom', dummy_arrange_bathroom)
+    monkeypatch.setattr(vastu_all_in_one, 'arrange_livingroom', dummy_arrange_livingroom)
+    monkeypatch.setattr(vastu_all_in_one.GenerateView, '_add_door_clearance', lambda *a, **k: None, raising=False)
+
+    gv._solve_and_draw()
+
+    assert "Kitchen must share" not in gv.status.msg
+    assert shares_edge(gv.kitch_plan, gv.bath_plan)
+    assert not shares_edge(gv.kitch_plan, gv.liv_plan)

--- a/tests/test_layout_adjacency.py
+++ b/tests/test_layout_adjacency.py
@@ -39,13 +39,10 @@ def layout_and_check(gv):
             gv.status.set(f"Rooms {name_a} and {name_b} overlap")
             return False
 
-    if gv.kitch_plan and gv.bath_plan and gv.liv_plan:
-        if not (
-            shares_edge(gv.kitch_plan, gv.bath_plan)
-            and shares_edge(gv.kitch_plan, gv.liv_plan)
-        ):
+    if gv.kitch_plan and gv.bath_plan:
+        if not shares_edge(gv.kitch_plan, gv.bath_plan):
             gv.status.set(
-                "Kitchen must share an edge with BOTH Living and Bathroom. Currently it does not."
+                "Kitchen must share a wall with the Bathroom. Currently it does not."
             )
             return False
 
@@ -126,8 +123,29 @@ def test_kitchen_shift_breaks_adjacency():
     assert not layout_and_check(gv)
     assert (
         gv.status.msg
-        == "Kitchen must share an edge with BOTH Living and Bathroom. Currently it does not."
+        == "Kitchen must share a wall with the Bathroom. Currently it does not."
     )
+
+
+def test_kitchen_bath_wall_living_indirect():
+    cell = CELL_M
+    gv = make_generate_view((cell, cell), living_dims=(cell, cell))
+    gv.bed_plan = GridPlan(cell, cell)
+    gv.bath_plan = GridPlan(cell, cell)
+    gv.liv_plan = GridPlan(cell, cell)
+    gv.kitch_plan = GridPlan(cell, cell)
+
+    gv.bed_plan.x_offset = 0
+    gv.bed_plan.y_offset = 0
+    gv.bath_plan.x_offset = 1
+    gv.bath_plan.y_offset = 0
+    gv.kitch_plan.x_offset = 1
+    gv.kitch_plan.y_offset = 1
+    gv.liv_plan.x_offset = 0
+    gv.liv_plan.y_offset = 2  # separated by a hall space
+
+    assert layout_and_check(gv)
+    assert gv.status.msg == ""
 
 
 def test_living_room_overlap_raises_error():

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -3936,18 +3936,15 @@ class GenerateView:
                         self.plan = prev_plan
                     return
 
-            if kitch_plan and bath_plan and liv_plan:
+            if kitch_plan and bath_plan:
                 share_bath = shares_edge(kitch_plan, bath_plan)
-                share_liv = shares_edge(kitch_plan, liv_plan)
-                if share_bath and share_liv:
+                if share_bath:
                     adjacency_ok = True
                     break
-                if not share_bath:
-                    regen_bath = True
-                    regen_kitch = True
-                if not share_liv:
+                regen_bath = True
+                regen_kitch = True
+                if liv_plan:
                     regen_liv = True
-                    regen_kitch = True
                 continue
             else:
                 adjacency_ok = True
@@ -3955,7 +3952,7 @@ class GenerateView:
 
         if not adjacency_ok and not failure_msg:
             self.status.set(
-                "Kitchen must share an edge with BOTH Living and Bathroom. Currently it does not."
+                "Kitchen must share a wall with the Bathroom. Currently it does not."
             )
             if prev_plan is not None:
                 self.plan = prev_plan


### PR DESCRIPTION
## Summary
- Relax kitchen adjacency to only require a shared wall with the bathroom
- Keep layouts where kitchen and living room are separated by hall space
- Add unit tests covering indirect kitchen–living connectivity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c076ea85148330a61735809cdbf667