### PR TITLE
Check furn tag before raising room

### DIFF
--- a/GDS last stable version.py
+++ b/GDS last stable version.py
@@ -4053,8 +4053,11 @@ class GenerateView:
             room_name,
         )
         cv.tag_lower('clear')
-        cv.tag_raise('furn', 'clear')
-        cv.tag_raise('room', 'furn')
+        if cv.find_withtag('furn'):
+            cv.tag_raise('furn', 'clear')
+            cv.tag_raise('room', 'furn')
+        else:
+            cv.tag_raise('room')
         cv.tag_raise('opening', 'room')
 
     def _draw_clearances(self, cv, plan, openings, ox, oy, scale):

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -4375,8 +4375,7 @@ class GenerateView:
             room_name,
         )
         cv.tag_lower('clear')
-        has_furn = bool(getattr(cv, 'find_withtag', lambda _tag: [])('furn'))
-        if has_furn:
+        if cv.find_withtag('furn'):
             cv.tag_raise('furn', 'clear')
             cv.tag_raise('room', 'furn')
         else:


### PR DESCRIPTION
## Summary
- Skip raising `room` above `furn` when no furniture exists
- Mirror this conditional z-ordering in the legacy drawing function

## Testing
- `PYTHONPATH=$PWD pytest tests/test_canvas_zorder.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1419857348330af78a94b37e23ff1