### PR TITLE
Fix kitchen solver invocation with required appliances

### DIFF
--- a/tests/test_adjacency_message.py
+++ b/tests/test_adjacency_message.py
@@ -79,7 +79,7 @@ def test_kitchen_adjacency_failure_sets_status(monkeypatch):
         def __init__(self, plan, *a, **k):
             self.plan = plan
 
-        def run(self):
+        def run(self, appliance_sets=None):
             self.plan.place(1, 0, 1, 1, 'SINK')
             return self.plan, None
 

--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -98,6 +98,9 @@ class BoundingCanvas:
         ys = [b["bbox"][1] for b in self.items] + [b["bbox"][3] for b in self.items]
         return min(xs), min(ys), max(xs), max(ys)
 
+    def find_withtag(self, tag):
+        return [i for i, item in enumerate(self.items, 1) if tag in item.get('tags', ())]
+
 
 def make_generate_view(bath_dims=(2.0, 2.0), living_dims=None, kitch_dims=None):
     master = tk.Tcl()

--- a/tests/test_kitchen_bath_living_indirect.py
+++ b/tests/test_kitchen_bath_living_indirect.py
@@ -86,7 +86,7 @@ def test_indirect_living_connection(monkeypatch):
     class DummyKitchenSolver:
         def __init__(self, plan, *a, **k):
             self.plan = plan
-        def run(self):
+        def run(self, appliance_sets=None):
             self.plan.place(0, 0, 1, 1, 'SINK')
             return self.plan, None
 

--- a/tests/test_ruler_labels.py
+++ b/tests/test_ruler_labels.py
@@ -60,6 +60,9 @@ class CountingCanvas:
     def itemconfigure(self, *args, **kwargs):
         pass
 
+    def find_withtag(self, tag):
+        return []
+
 
 
 def test_ruler_labels_persist_across_zoom():

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -3829,7 +3829,9 @@ class GenerateView:
                         random.Random(),
                         getattr(self, 'weights', {}),
                     )
-                    kbest, _ = ksolver.run()
+                    kbest, _kmeta = ksolver.run(
+                        appliance_sets=[tuple(self.REQUIRED_FURNITURE['kitch_plan'])]
+                    )
                     if isinstance(kbest, GridPlan):
                         if self.kitch_openings:
                             dx, dy, dw, dh = self.kitch_openings.door_rect_cells()


### PR DESCRIPTION
## Summary
- Ensure `_solve_and_draw` passes required kitchen appliance set to `KitchenSolver.run`
- Extend kitchen-related tests to accept the new argument
- Provide minimal `find_withtag` implementations for canvas test doubles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c14339bd448330b72d4cb783ca66e6