### PR TITLE
Add required parameter for kitchen solver appliance sets

### DIFF
--- a/GDS last stable version.py
+++ b/GDS last stable version.py
@@ -2,7 +2,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 from collections import deque, defaultdict, Counter
 from math import ceil, sqrt, floor
-from typing import Optional, Dict, Tuple, List, Set
+from typing import Optional, Dict, Tuple, List, Set, Iterable
 import time, json, random, os, itertools, re
 import numpy as np
 import warnings
@@ -2488,10 +2488,13 @@ class KitchenSolver:
 
     def run(self,
             appliance_sets: Optional[List[Tuple[str, ...]]] = None,
+            required: Iterable[str] = (),
             iters: int = 200,
             time_budget_ms: int = 520,
             max_attempts: int = 3,
             min_adjacency: float = 0.0) -> Tuple[Optional[GridPlan], Dict]:
+        if not appliance_sets and required:
+            appliance_sets = [tuple(required)]
         sets = appliance_sets or default_kitchen_sets()
         best_overall = None; meta_overall = None
         for req in reversed(sets):

--- a/tests/test_adjacency_message.py
+++ b/tests/test_adjacency_message.py
@@ -79,7 +79,7 @@ def test_kitchen_adjacency_failure_sets_status(monkeypatch):
         def __init__(self, plan, *a, **k):
             self.plan = plan
 
-        def run(self, appliance_sets=None):
+        def run(self, appliance_sets=None, required=()):
             self.plan.place(1, 0, 1, 1, 'SINK')
             return self.plan, None
 

--- a/tests/test_kitchen_bath_living_indirect.py
+++ b/tests/test_kitchen_bath_living_indirect.py
@@ -86,7 +86,7 @@ def test_indirect_living_connection(monkeypatch):
     class DummyKitchenSolver:
         def __init__(self, plan, *a, **k):
             self.plan = plan
-        def run(self, appliance_sets=None):
+        def run(self, appliance_sets=None, required=()):
             self.plan.place(0, 0, 1, 1, 'SINK')
             return self.plan, None
 

--- a/vastu_all_in_one.py
+++ b/vastu_all_in_one.py
@@ -2,7 +2,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox, filedialog
 from collections import deque, defaultdict, Counter
 from math import ceil, sqrt, floor
-from typing import Optional, Dict, Tuple, List, Set, ClassVar
+from typing import Optional, Dict, Tuple, List, Set, ClassVar, Iterable
 import time, json, random, os, itertools, re
 import numpy as np
 import warnings
@@ -2546,10 +2546,13 @@ class KitchenSolver:
 
     def run(self,
             appliance_sets: Optional[List[Tuple[str, ...]]] = None,
+            required: Iterable[str] = (),
             iters: int = 200,
             time_budget_ms: int = 520,
             max_attempts: int = 3,
             min_adjacency: float = 0.0) -> Tuple[Optional[GridPlan], Dict]:
+        if not appliance_sets and required:
+            appliance_sets = [tuple(required)]
         sets = appliance_sets or default_kitchen_sets()
         best_overall = None; meta_overall = None
         for req in reversed(sets):
@@ -3830,7 +3833,7 @@ class GenerateView:
                         getattr(self, 'weights', {}),
                     )
                     kbest, _kmeta = ksolver.run(
-                        appliance_sets=[tuple(self.REQUIRED_FURNITURE['kitch_plan'])]
+                        required=self.REQUIRED_FURNITURE['kitch_plan']
                     )
                     if isinstance(kbest, GridPlan):
                         if self.kitch_openings:


### PR DESCRIPTION
## Summary
- Allow `KitchenSolver.run` to accept a `required` iterable, defaulting to an empty tuple, and convert it into appliance sets when no sets are provided
- Invoke `KitchenSolver.run` with required kitchen furniture in `_solve_and_draw`
- Adjust tests to accommodate the new API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1442816908330bab2119c5f416d1b