### PR TITLE
Auto-scale living width from door spacing

### DIFF
--- a/gds.py
+++ b/gds.py
@@ -3532,6 +3532,50 @@ class GenerateView:
             self.liv_bath_openings.swing_depth = self.bath_liv_openings.swing_depth
         else:
             self.liv_bath_openings = None
+        # Automatically adjust living room width based on bedroom/bathroom door spacing.
+        if (
+            getattr(self, "liv_dims", None)
+            and getattr(self, "bed_openings", None)
+            and getattr(self, "bath_liv_openings", None)
+        ):
+            bed_wall, bed_start, bed_width = self.bed_openings.door_span_cells()
+            bath_wall, bath_start, bath_width = self.bath_liv_openings.door_span_cells()
+
+            def _horiz_edges(plan: GridPlan, wall: int, start: int, width: int) -> Tuple[int, int]:
+                if wall in (WALL_BOTTOM, WALL_TOP):
+                    left = plan.x_offset + start
+                    right = left + width
+                elif wall == WALL_LEFT:
+                    left = right = plan.x_offset
+                else:  # WALL_RIGHT
+                    left = right = plan.x_offset + plan.gw
+                return left, right
+
+            bed_left, bed_right = _horiz_edges(self.bed_plan, bed_wall, bed_start, bed_width)
+            bath_left, bath_right = _horiz_edges(self.bath_plan, bath_wall, bath_start, bath_width)
+            span_left = min(bed_left, bath_left)
+            span_right = max(bed_right, bath_right)
+            req_width = (span_right - span_left) * CELL_M + 0.05
+            self.liv_dims = (req_width, self.liv_dims[1])
+            self.liv_Wm = req_width
+            self._validate_living_dims()
+            old_openings = getattr(self, "liv_openings", None)
+            self.liv_plan = GridPlan(self.liv_Wm, self.liv_Hm)
+            if old_openings:
+                self.liv_openings = Openings(self.liv_plan)
+                self.liv_openings.door_wall = old_openings.door_wall
+                self.liv_openings.door_center = old_openings.door_center
+                self.liv_openings.door_width = old_openings.door_width
+                self.liv_openings.swing_depth = old_openings.swing_depth
+            else:
+                self.liv_openings = Openings(self.liv_plan)
+                self.liv_openings.swing_depth = 0.60
+            if getattr(self, "bath_liv_openings", None):
+                self.liv_bath_openings = Openings(self.liv_plan)
+                self.liv_bath_openings.door_wall = opposite_wall(self.bath_liv_openings.door_wall)
+                self.liv_bath_openings.door_center = self.bath_liv_openings.door_center
+                self.liv_bath_openings.door_width = self.bath_liv_openings.door_width
+                self.liv_bath_openings.swing_depth = self.bath_liv_openings.swing_depth
         return True
     def _apply_batch_and_generate(self):
         # (1) snapshot only if you want to keep a LOCKED item; otherwise clear

--- a/tests/test_generate_view.py
+++ b/tests/test_generate_view.py
@@ -928,6 +928,7 @@ def test_bath_living_door_drawn_and_mirrored(monkeypatch):
 
     gv.bed_openings.door_wall = WALL_RIGHT
 
+    gv.bed_plan = GridPlan(gv.bed_Wm, gv.bed_Hm)
     gv.bath_plan = GridPlan(*gv.bath_dims)
     gv.liv_plan = GridPlan(*gv.liv_dims)
     gv.bath_plan.x_offset = 0
@@ -955,6 +956,38 @@ def test_bath_living_door_drawn_and_mirrored(monkeypatch):
 
     assert calls.get(gv.bath_liv_openings) is True
     assert calls.get(gv.liv_bath_openings) is True
+
+
+def test_living_width_scales_with_door_spacing():
+    gv = GenerateView.__new__(GenerateView)
+    gv.status = DummyStatus()
+    gv.bed_Wm = gv.bed_Hm = 4.0
+    gv.bath_dims = (2.0, 2.0)
+    gv.bath_Wm, gv.bath_Hm = gv.bath_dims
+    gv.liv_dims = (3.0, 2.0)
+    gv.liv_Wm, gv.liv_Hm = gv.liv_dims
+    gv.bed_plan = GridPlan(gv.bed_Wm, gv.bed_Hm)
+    gv.bath_plan = GridPlan(*gv.bath_dims)
+    gv.liv_plan = GridPlan(*gv.liv_dims)
+    gv.bed_plan.x_offset = 0
+    gv.bath_plan.x_offset = gv.bed_plan.gw + 20  # place bathroom further right
+    gv.bed_openings = Openings(gv.bed_plan)
+    gv.bed_openings.door_wall = WALL_RIGHT
+    gv.bed_openings.swing_depth = CELL_M
+    gv.bath_liv_openings = Openings(gv.bath_plan)
+    gv.bath_liv_openings.door_wall = WALL_BOTTOM
+    gv.bath_liv_openings.swing_depth = CELL_M
+    gv.liv_bath_openings = Openings(gv.liv_plan)
+    gv.liv_bath_openings.swing_depth = CELL_M
+    gv.liv_openings = Openings(gv.liv_plan)
+    gv.liv_openings.swing_depth = 0.60
+    assert GenerateView._apply_openings_from_ui(gv)
+    bed_wall, bed_start, bed_width = gv.bed_openings.door_span_cells()
+    bath_wall, bath_start, bath_width = gv.bath_liv_openings.door_span_cells()
+    bed_left = gv.bed_plan.x_offset + gv.bed_plan.gw
+    bath_right = gv.bath_plan.x_offset + bath_start + bath_width
+    expected = max((bath_right - bed_left) * CELL_M + 0.05, gv.bed_Wm)
+    assert gv.liv_dims[0] == pytest.approx(expected)
 
 def test_init_schedules_solver(monkeypatch):
     import gds


### PR DESCRIPTION
## Summary
- derive living room width from bedroom/bathroom door spacing
- rebuild living room plan and openings to match new width
- test living width scaling logic

## Testing
- `python3 -m pytest tests/test_generate_view.py::test_living_width_scales_with_door_spacing -vv`
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c16837acf88330add22c6420bb8398