### PR TITLE
Handle uncaught exceptions in main execution

### DIFF
--- a/gds.py
+++ b/gds.py
@@ -5756,25 +5756,28 @@ class App:
         self.landing.pack(fill=tk.BOTH, expand=True)
         self._build_landing()
 
-# ---- AND REPLACE YOUR MAIN GUARD WITH THIS -----------------------------------
-
-if __name__ == "__main__":
+# configure logging early so the main guard can report failures
+def _setup_logging() -> None:
+    """Configure root logging based on a ``--log-level`` argument."""
     import argparse
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument(
         "--log-level",
         default="INFO",
         help="Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
     )
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
     logging.basicConfig(
         level=getattr(logging, args.log_level.upper(), logging.INFO),
         force=True,
     )
+
+
+_setup_logging()
+
+if __name__ == "__main__":
     try:
         App().run()
-    except Exception:
-        logger.exception("Unhandled exception in main")
-
-# ---- END REPLACEMENT ---------------------------------------------------------
+    except Exception as exc:
+        logging.exception("Application crashed: %s", exc)


### PR DESCRIPTION
## Summary
- Configure root logging via command-line `--log-level` before starting the app
- Wrap `App().run()` in a try/except block to log any uncaught exceptions

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17b6ecb2083309aae534775b4d584