### PR TITLE
Support multi-segment rooms with flexible door placement

### DIFF
--- a/gds.py
+++ b/gds.py
@@ -20,26 +20,76 @@ def checkpoint(label: str, **context: Any) -> None:
     else:
         logger.debug(label)
 
+def _iter_segments(plan):
+    """Yield rectangular segments for ``plan``.
+
+    ``GridPlan`` instances represent a single rectangle.  A plan may expose a
+    ``segments`` attribute to behave as a collection of rectangles that together
+    form a single room.  This helper normalises both representations so the
+    geometric helpers can operate on either form."""
+
+    return getattr(plan, "segments", [plan])
+
+
 def overlaps(a, b) -> bool:
-    """Return ``True`` if axis-aligned plans ``a`` and ``b`` overlap."""
-    ax0, ay0 = a.x_offset, a.y_offset
-    ax1, ay1 = ax0 + a.gw, ay0 + a.gh
-    bx0, by0 = b.x_offset, b.y_offset
-    bx1, by1 = bx0 + b.gw, by0 + b.gh
-    return not (ax1 <= bx0 or bx1 <= ax0 or ay1 <= by0 or by1 <= ay0)
+    """Return ``True`` if axis-aligned plans ``a`` and ``b`` overlap.
+
+    ``a`` or ``b`` may themselves be composed of multiple rectangular segments.
+    The function returns ``True`` when any pair of segments overlap."""
+
+    for sa in _iter_segments(a):
+        ax0, ay0 = sa.x_offset, sa.y_offset
+        ax1, ay1 = ax0 + sa.gw, ay0 + sa.gh
+        for sb in _iter_segments(b):
+            bx0, by0 = sb.x_offset, sb.y_offset
+            bx1, by1 = bx0 + sb.gw, by0 + sb.gh
+            if not (ax1 <= bx0 or bx1 <= ax0 or ay1 <= by0 or by1 <= ay0):
+                return True
+    return False
 
 def shares_edge(a, b) -> bool:
-    """Return ``True`` when plans ``a`` and ``b`` share a boundary edge."""
-    ax0, ay0 = a.x_offset, a.y_offset
-    ax1, ay1 = ax0 + a.gw, ay0 + a.gh
-    bx0, by0 = b.x_offset, b.y_offset
-    bx1, by1 = bx0 + b.gw, by0 + b.gh
-    return (
-        (ax1 == bx0 and max(ay0, by0) < min(ay1, by1))
-        or (bx1 == ax0 and max(ay0, by0) < min(ay1, by1))
-        or (ay1 == by0 and max(ax0, bx0) < min(ax1, bx1))
-        or (by1 == ay0 and max(ax0, bx0) < min(ax1, bx1))
-    )
+    """Return ``True`` when plans ``a`` and ``b`` share a boundary edge.
+
+    Works with simple ``GridPlan`` instances as well as compound plans exposing
+    a ``segments`` attribute."""
+
+    for sa in _iter_segments(a):
+        ax0, ay0 = sa.x_offset, sa.y_offset
+        ax1, ay1 = ax0 + sa.gw, ay0 + sa.gh
+        for sb in _iter_segments(b):
+            bx0, by0 = sb.x_offset, sb.y_offset
+            bx1, by1 = bx0 + sb.gw, by0 + sb.gh
+            if (
+                (ax1 == bx0 and max(ay0, by0) < min(ay1, by1))
+                or (bx1 == ax0 and max(ay0, by0) < min(ay1, by1))
+                or (ay1 == by0 and max(ax0, bx0) < min(ax1, bx1))
+                or (by1 == ay0 and max(ax0, bx0) < min(ax1, bx1))
+            ):
+                return True
+    return False
+
+
+def shared_wall(a, b) -> int:
+    """Return the wall of ``a`` that touches ``b`` or ``-1`` if none.
+
+    The function iterates over all segments of ``a`` and ``b`` and returns the
+    first wall of ``a`` that directly abuts ``b``."""
+
+    for sa in _iter_segments(a):
+        ax0, ay0 = sa.x_offset, sa.y_offset
+        ax1, ay1 = ax0 + sa.gw, ay0 + sa.gh
+        for sb in _iter_segments(b):
+            bx0, by0 = sb.x_offset, sb.y_offset
+            bx1, by1 = bx0 + sb.gw, by0 + sb.gh
+            if ax1 == bx0 and max(ay0, by0) < min(ay1, by1):
+                return WALL_RIGHT
+            if bx1 == ax0 and max(ay0, by0) < min(ay1, by1):
+                return WALL_LEFT
+            if ay1 == by0 and max(ax0, bx0) < min(ax1, bx1):
+                return WALL_TOP
+            if by1 == ay0 and max(ax0, bx0) < min(ax1, bx1):
+                return WALL_BOTTOM
+    return -1
 BED_RULES_FILE = os.path.join(os.path.dirname(__file__), "rules.bedroom.json")
 BATH_RULES_FILE = os.path.join(os.path.dirname(__file__), "rules.bathroom.json")
 LIV_RULES_FILE = os.path.join(os.path.dirname(__file__), "rules.livingroom.json")

--- a/multiroom.py
+++ b/multiroom.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from gds import (
+    GridPlan,
+    Openings,
+    CELL_M,
+    WALL_LEFT,
+    WALL_RIGHT,
+    WALL_TOP,
+    WALL_BOTTOM,
+    opposite_wall,
+    shared_wall,
+)
+
+
+@dataclass
+class MultiRectRoom:
+    """A room composed of multiple rectangular ``GridPlan`` segments."""
+
+    segments: List[GridPlan]
+
+    def total_area(self) -> float:
+        """Return the combined area of all segments in square metres."""
+        return sum(seg.Wm * seg.Hm for seg in self.segments)
+
+    def meets_constraints(
+        self, min_area: float, min_width: float, min_height: float
+    ) -> bool:
+        """Check total area and per-segment dimension constraints.
+
+        ``min_area`` applies to the sum of all segments while ``min_width`` and
+        ``min_height`` must be satisfied by each individual segment."""
+
+        if self.total_area() < min_area:
+            return False
+        for seg in self.segments:
+            if seg.Wm < min_width or seg.Hm < min_height:
+                return False
+        return True
+
+    def segment_for_neighbor(self, neighbor: GridPlan) -> Tuple[Optional[GridPlan], int]:
+        """Return the segment and wall that touches ``neighbor``."""
+        for seg in self.segments:
+            wall = shared_wall(seg, neighbor)
+            if wall != -1:
+                return seg, wall
+        return None, -1
+
+    def place_door_to(self, neighbor: GridPlan, width: float = CELL_M) -> None:
+        """Place a door between this room and ``neighbor``.
+
+        The method selects the segment that borders ``neighbor`` and carves out a
+        door of ``width`` metres on the shared wall.  A matching door is also
+        carved on the neighbour's opposing wall."""
+
+        segment, wall = self.segment_for_neighbor(neighbor)
+        if segment is None:
+            raise ValueError("No adjacent segment available for door placement")
+        op = Openings(segment)
+        op.door_wall = wall
+        op.door_width = width
+        dx, dy, dw, dh = op.door_rect_cells()
+        for j in range(dy, dy + dh):
+            for i in range(dx, dx + dw):
+                segment.occ[j][i] = "DOOR"
+        # mirror door on neighbour
+        op2 = Openings(neighbor)
+        op2.door_wall = opposite_wall(wall)
+        op2.door_width = width
+        dx, dy, dw, dh = op2.door_rect_cells()
+        for j in range(dy, dy + dh):
+            for i in range(dx, dx + dw):
+                neighbor.occ[j][i] = "DOOR"

--- a/tests/test_multi_segment_room.py
+++ b/tests/test_multi_segment_room.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+# Ensure repository root importable when tests run from this directory
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from gds import GridPlan, CELL_M, WALL_LEFT, WALL_RIGHT
+from multiroom import MultiRectRoom
+
+
+def test_multi_segment_room_doors_and_constraints():
+    cell = CELL_M
+    seg1 = GridPlan(2 * cell, cell)
+    seg1.x_offset = 1
+    seg1.y_offset = 0
+    seg2 = GridPlan(2 * cell, cell)
+    seg2.x_offset = 4
+    seg2.y_offset = 0
+    room = MultiRectRoom([seg1, seg2])
+
+    assert room.meets_constraints(
+        min_area=4 * cell * cell, min_width=cell, min_height=cell
+    )
+
+    left_neighbor = GridPlan(cell, cell)
+    left_neighbor.x_offset = 0
+    left_neighbor.y_offset = 0
+    right_neighbor = GridPlan(cell, cell)
+    right_neighbor.x_offset = 6
+    right_neighbor.y_offset = 0
+
+    seg, wall = room.segment_for_neighbor(left_neighbor)
+    assert seg is seg1 and wall == WALL_LEFT
+    seg, wall = room.segment_for_neighbor(right_neighbor)
+    assert seg is seg2 and wall == WALL_RIGHT
+
+    room.place_door_to(left_neighbor, width=cell)
+    room.place_door_to(right_neighbor, width=cell)
+
+    assert seg1.occ[0][0] == "DOOR"
+    assert seg2.occ[0][seg2.gw - 1] == "DOOR"
+    assert left_neighbor.occ[0][left_neighbor.gw - 1] == "DOOR"
+    assert right_neighbor.occ[0][0] == "DOOR"


### PR DESCRIPTION
## Summary
- Allow geometric helpers to iterate over multiple room segments and expose a `shared_wall` routine
- Introduce `MultiRectRoom` for rooms built from multiple rectangles with area and dimension checks and automatic door placement
- Test rooms spanning multiple segments can connect to different neighbours via doors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c185e92c9083308f30241e8d302937