### PR TITLE
Guard GenerateView drawing for small canvases

### DIFF
--- a/gds.py
+++ b/gds.py
@@ -4024,13 +4024,22 @@ class GenerateView:
         bottom_h = max(liv_gh, kitch_gh)
         total_w = max(top_w, bottom_w)
         total_h = top_h + bottom_h
-        cw, ch = cv.winfo_width() or 1, cv.winfo_height() or 1
         margin = 26
+        getattr(cv, 'update_idletasks', lambda: None)()
+        cw, ch = cv.winfo_width() or 1, cv.winfo_height() or 1
+        if cw <= 2 * margin or ch <= 2 * margin:
+            cv.after_idle(self._draw)
+            return
         scale = min((cw - 2 * margin) / max(1, total_w),
                     (ch - 2 * margin) / max(1, total_h))
         r = max(8, scale * 0.3)
         label_gap = r * 2.5
         margin = max(26, label_gap + 10)
+        if cw <= 2 * margin or ch <= 2 * margin:
+            cv.after_idle(self._draw)
+            return
+        cw = max(cw, 2 * margin + 1)
+        ch = max(ch, 2 * margin + 1)
         scale = min((cw - 2 * margin) / max(1, total_w),
                     (ch - 2 * margin) / max(1, total_h))
         zf = (self.zoom_factor.get()

--- a/tests/test_small_canvas_draw.py
+++ b/tests/test_small_canvas_draw.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from gds import GenerateView, GridPlan
+
+class TinyCanvas:
+    def __init__(self, w, h):
+        self.w = w
+        self.h = h
+        self.after_idle_called_with = None
+    def winfo_width(self):
+        return self.w
+    def winfo_height(self):
+        return self.h
+    def delete(self, *args, **kwargs):
+        pass
+    def update_idletasks(self):
+        pass
+    def after_idle(self, func):
+        self.after_idle_called_with = func
+
+
+def test_draw_reschedules_on_too_small_canvas_and_draws_after_resize():
+    gv = GenerateView.__new__(GenerateView)
+    gv.canvas = TinyCanvas(10, 10)
+    gv.zoom_factor = 1
+    gv.bed_plan = GridPlan(1.0, 1.0)
+    gv.bed_openings = object()
+    gv.bath_plan = gv.liv_plan = gv.kitch_plan = None
+    gv.plan = gv.bed_plan
+    gv.sim_path = gv.sim_poly = gv.sim2_path = gv.sim2_poly = []
+    gv.grid_overlay = type('G', (), {'redraw': lambda *a, **k: None})()
+    gv.popover = type('P', (), {'hide': lambda self: None})()
+    gv._draw_all_layers = lambda *a, **k: None
+
+    gv._draw()
+    assert gv.canvas.after_idle_called_with == gv._draw
+
+    gv.canvas.w = gv.canvas.h = 400
+    called = {'count': 0}
+    gv._draw_all_layers = lambda *a, **k: called.update(count=called['count'] + 1)
+    gv._draw()
+    assert called['count'] == 1


### PR DESCRIPTION
## Summary
- Ensure `GenerateView._draw` updates canvas geometry before measuring
- Skip rendering when the canvas is too small and reschedule draw
- Clamp canvas dimensions when recomputing scale so it stays positive
- Add regression test covering draw reschedule and redraw after resize

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c18a01c860833089079cdea9463fd7